### PR TITLE
* src/hdgeant4.cc [rtj]

### DIFF
--- a/src/GlueXUserEventInformation.cc
+++ b/src/GlueXUserEventInformation.cc
@@ -42,7 +42,9 @@ GlueXUserEventInformation::~GlueXUserEventInformation()
       }
       if (fKeepEvent) {
          hddm_s::PhysicsEventList pev = fOutputRecord->getPhysicsEvents();
-         pev(0).setRunNo(HddmOutput::getRunNo());
+         int runno = HddmOutput::getRunNo();
+         if (runno > 0)
+            pev(0).setRunNo(runno);
          if (pev(0).getEventNo() == 0) {
             pev(0).setEventNo(HddmOutput::incrementEventNo());
          }

--- a/src/hdgeant4.cc
+++ b/src/hdgeant4.cc
@@ -85,8 +85,8 @@ int main(int argc,char** argv)
       else {
          G4cerr << "Warning - "
                 << "no run number specified in control.in, "
-                << "default value of 9000 assumed." << G4endl;
-         run_number = 9000;
+                << "default value of 0 assumed." << G4endl;
+         run_number = 0;
       }
    }
 


### PR DESCRIPTION
   - change the default run number from 9000 to 0
   - users are expected to set run number in control.in or else it will
     default to the run number in the input hddm file, if any.

* src/GlueXUserEventInformation.cc [rtj]
   - use the run number from the input file unless it is overridden in
     the control.in file, same behavior as hdgeant.