### PR TITLE
- suppress the generation of the RFtime tag in the hddm output file,

### DIFF
--- a/src/GlueXPrimaryGeneratorAction.cc
+++ b/src/GlueXPrimaryGeneratorAction.cc
@@ -418,7 +418,6 @@ void GlueXPrimaryGeneratorAction::GeneratePrimariesHDDM(G4Event* anEvent)
       t -= GlueXPhotonBeamGenerator::GenerateTriggerTime(anEvent);
       fPrimaryGenerator->SetParticleTime(t);
       fPrimaryGenerator->GeneratePrimaryVertex(anEvent);
-      GlueXPhotonBeamGenerator::GenerateRFsync(anEvent);
       GlueXUserEventInformation *eventinfo;
       eventinfo = (GlueXUserEventInformation*)anEvent->GetUserInformation();
       if (eventinfo) {


### PR DESCRIPTION
  as it conflicts with the meaning and usage of the DRFtime object in
  jana, and this is redundant information anyway.