### PR TITLE
- remove the DISABLE switch on the PostStepDoIt trigger

### DIFF
--- a/src/GlueXBeamConversionProcess.hh
+++ b/src/GlueXBeamConversionProcess.hh
@@ -45,8 +45,8 @@ class GlueXBeamConversionProcess: public G4VDiscreteProcess
    static PairConversionGeneration *fPairsGeneration;
 #endif
 
-   int fStopBeamBeforeConversion;
-   int fStopBeamAfterConversion;
+   int fStopBeamBeforeConverter;
+   int fStopBeamAfterConverter;
 
    void prepareImportanceSamplingPDFs();
 


### PR DESCRIPTION
- remove the artificial energy threshold on beam sampling in the
  TPOL converter target
- rename fStopBeamAfterConversion to fStopBeamAfterConverter, and
  fStopBeamBeforeConversion to fStopBeamBeforeConverter to make it
  more clear what these flags actually do.