### PR TITLE
* src/hdgeant4.cc [rtj]

### DIFF
--- a/src/OpenGLXpreload.cc
+++ b/src/OpenGLXpreload.cc
@@ -1,0 +1,14 @@
+#include  <GL/glx.h>
+#include  <GL/gl.h>
+#include  <unistd.h>
+
+static int attributeList[] = { GLX_RGBA, None };
+
+void OpenGLXpreload() {
+    Display *dpy;
+    XVisualInfo *vi;
+    /* get a connection */
+    dpy = XOpenDisplay(0);
+    /* get an appropriate visual */
+    vi = glXChooseVisual(dpy, DefaultScreen(dpy), attributeList);
+}

--- a/src/hdgeant4.cc
+++ b/src/hdgeant4.cc
@@ -46,6 +46,8 @@ void usage()
    exit(9);
 }
 
+void OpenGLXpreload();
+
 int main(int argc,char** argv)
 {
    // Initialize the jana framework
@@ -70,6 +72,13 @@ int main(int argc,char** argv)
       else {
          usage();
       }
+   }
+
+   // Initialize the graphics subsystem, if requested
+   if (use_visualization) {
+#ifdef G4VIS_USE
+      OpenGLXpreload();
+#endif
    }
 
    // Read user options from file control.in


### PR DESCRIPTION
   - add a call to OpenGLXpreload() to preload the graphics libraries
     before the main initialization code starts and grabs all of the
     available TLS space. This change fixes a failure that appears on
     machines with nvidia graphics drivers, because all fo the TLS space
     has been allocated by the time the /vis/viewer/open command
     finally runs in the vis.mac startup macro.

* src/OpenGLXpreload.cc [rtj]
   - implementation of OpenGLXpreload(), see above.