### PR TITLE
- fix the logic for handling the end-of-file condition on hddm input.

### DIFF
--- a/src/GlueXPrimaryGenerator.cc
+++ b/src/GlueXPrimaryGenerator.cc
@@ -14,6 +14,7 @@
 #include "GlueXPrimaryGeneratorAction.hh"
 #include "GlueXUserEventInformation.hh"
 #include "G4SystemOfUnits.hh"
+#include "G4RunManager.hh"
 
 #include <HDDM/hddm_s.hpp>
 
@@ -27,12 +28,10 @@ GlueXPrimaryGenerator::~GlueXPrimaryGenerator()
 void GlueXPrimaryGenerator::GeneratePrimaryVertex(G4Event *event)
 {
    hddm_s::HDDM *hddmevent = new hddm_s::HDDM;
-   try {
-      *fHDDMistream >> *hddmevent;
-   }
-   catch(std::exception e) {
-      G4cout << e.what() << G4endl;
+   if (! (*fHDDMistream >> *hddmevent)) {
       event->SetEventAborted();
+      G4cout << "End of file on hddm input, ending the run here." << std::endl;
+      G4RunManager::GetRunManager()->AbortRun();
       return;
    }
 

--- a/src/GlueXPrimaryGeneratorAction.cc
+++ b/src/GlueXPrimaryGeneratorAction.cc
@@ -424,6 +424,9 @@ void GlueXPrimaryGeneratorAction::GeneratePrimariesHDDM(G4Event* anEvent)
          double E = eventinfo->GetBeamPhotonEnergy();
          GlueXPhotonBeamGenerator::GenerateTaggerHit(anEvent, E, t);
       }
+      else {
+         return;
+      }
    }
    ++fEventCount;
 


### PR DESCRIPTION
  The old logic was based on signals, but hddm does not send a signal
  at eof, it just sets the stream to logical false the way that the
  iostream and fstream classes do.
- if GeneratePrimaryVertex does not create a GlueXUserInformation object
  then take that as an indication that the run has terminated.