### PR TITLE
* src/GlueXPhotonBeamGenerator.cc, hh [rtj]

### DIFF
--- a/src/GlueXPhotonBeamGenerator.hh
+++ b/src/GlueXPhotonBeamGenerator.hh
@@ -60,6 +60,7 @@ class GlueXPhotonBeamGenerator: public G4VPrimaryGenerator
    static double getBeamVelocity() {
       return fBeamVelocity;
    }
+   static double getRFreferencePlaneZ(int runno=0);
    static double getBeamBucketPeriod(int runno=0);
    static void setBeamBucketPeriod(double period) {
       fBeamBucketPeriod = period;

--- a/src/GlueXPrimaryGeneratorAction.cc
+++ b/src/GlueXPrimaryGeneratorAction.cc
@@ -35,6 +35,7 @@ double GlueXPrimaryGeneratorAction::fBeamBackgroundRate = 0;
 double GlueXPrimaryGeneratorAction::fBeamBackgroundGateStart = 0;
 double GlueXPrimaryGeneratorAction::fBeamBackgroundGateStop = 0;
 double GlueXPrimaryGeneratorAction::fL1triggerTimeSigma = 10 * ns;
+double GlueXPrimaryGeneratorAction::fRFreferencePlaneZ = 65 * cm;
 double GlueXPrimaryGeneratorAction::fTargetCenterZ = 65 * cm;
 double GlueXPrimaryGeneratorAction::fTargetLength = 29.9746 * cm;
 
@@ -414,7 +415,7 @@ void GlueXPrimaryGeneratorAction::GeneratePrimariesHDDM(G4Event* anEvent)
       }
       z = fTargetCenterZ + (G4UniformRand() - 0.5) * fTargetLength;
       fPrimaryGenerator->SetParticlePosition(G4ThreeVector(x,y,z));
-      t = (z - fTargetCenterZ) / beamVelocity;
+      t = (z - fRFreferencePlaneZ) / beamVelocity;
       t -= GlueXPhotonBeamGenerator::GenerateTriggerTime(anEvent);
       fPrimaryGenerator->SetParticleTime(t);
       fPrimaryGenerator->GeneratePrimaryVertex(anEvent);

--- a/src/GlueXPrimaryGeneratorAction.hh
+++ b/src/GlueXPrimaryGeneratorAction.hh
@@ -95,6 +95,7 @@ class GlueXPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
    static double fBeamBackgroundGateStart;
    static double fBeamBackgroundGateStop;
    static double fL1triggerTimeSigma;
+   static double fRFreferencePlaneZ;
 
    static int fEventCount;
 
@@ -127,6 +128,12 @@ class GlueXPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
    }
    static double getL1triggerTimeSigma() {
       return fL1triggerTimeSigma;
+   }
+   static void setRFreferencePlaneZ(double refZ) {
+      fRFreferencePlaneZ = refZ;
+   }
+   static double getRFreferencePlaneZ() {
+      return fRFreferencePlaneZ;
    }
    int getEventCount() const {
       return fEventCount;


### PR DESCRIPTION
   - modified to read the RFreferencePlaneZ from ccdb instead of
     hard-coding it to 65 cm, as was the case formerly.

* src/GlueXPrimaryGeneratorAction.cc, hh [rtj]
   - modified to use the RFreferencePlaneZ constant fetched from ccdb by
     GlueXPhotonBeamGenerator::getRFreferencePlaneZ() instead of
     assuming that the reference plane is fixed at 65 cm.