### PR TITLE
* src/GlueXDetectorConstruction.cc [rtj]

### DIFF
--- a/src/GlueXDetectorConstruction.cc
+++ b/src/GlueXDetectorConstruction.cc
@@ -323,7 +323,7 @@ void GlueXDetectorConstruction::ConstructSDandField()
          }
          iter->second->SetSensitiveDetector(bcalHandler);
       }
-      else if (volname == "LGBL") {
+      else if (volname == "LGBL" || volname == "LGLG") {
          if (fcalHandler == 0) {
             fcalHandler = new GlueXSensitiveDetectorFCAL("fcal");
             SDman->AddNewDetector(fcalHandler);

--- a/src/GlueXHitFCALblock.cc
+++ b/src/GlueXHitFCALblock.cc
@@ -25,7 +25,9 @@ int GlueXHitFCALblock::operator==(const GlueXHitFCALblock &right) const
 
    for (int ih=0; ih < (int)hits.size(); ++ih) {
       if (hits[ih].E_GeV != right.hits[ih].E_GeV ||
-          hits[ih].t_ns != right.hits[ih].t_ns)
+          hits[ih].t_ns != right.hits[ih].t_ns ||
+          hits[ih].dE_lightguide_GeV != right.hits[ih].dE_lightguide_GeV ||
+          hits[ih].t_lightguide_ns != right.hits[ih].t_lightguide_ns)
       {
          return 0;
       }
@@ -67,6 +69,10 @@ void GlueXHitFCALblock::Print() const
    for (hiter = hits.begin(); hiter != hits.end(); ++hiter) {
       G4cout << "   E = " << hiter->E_GeV << " GeV" << G4endl
              << "   t = " << hiter->t_ns << " ns" << G4endl
+             << "   E(lightguide) = " 
+             << hiter->dE_lightguide_GeV << " GeV" << G4endl
+             << "   t(lightguide) = " 
+             << hiter->t_lightguide_ns << " ns" << G4endl
              << G4endl;
    }
 }

--- a/src/GlueXHitFCALblock.hh
+++ b/src/GlueXHitFCALblock.hh
@@ -37,6 +37,8 @@ class GlueXHitFCALblock : public G4VHit
    struct hitinfo_t {
       G4double E_GeV;      // energy deposition (GeV)
       G4double t_ns;       // pulse leading-edge time (ns)
+      G4double dE_lightguide_GeV;  // light guide energy deposition (GeV)
+      G4double t_lightguide_ns;    // light guide pulse leading-edge time (ns)
    };
    std::vector<hitinfo_t> hits;
 


### PR DESCRIPTION
   - add light guide on the back of each fcal block as a sensitive
     volume, to allow recording of Cerenkov light emitted inside the
     light guide by punch-through charged particles, eg. muons and
     pions.
* src/GlueXHitFCALblock.cc, .hh [rtj]
   - add elements to hold light guide energy deposition and hit
     times.
* src/GlueXSensitiveDetectorFCAL.cc [rtj]
   - add code to record hits in the fcal light guides during tracking,
     and write out the light guide hit information to the output record
     at the end of the tracking phase for each event.