### PR TITLE
* src/GlueXDetectorConstruction.cc, .hh [rtj]

### DIFF
--- a/src/GlueXDetectorConstruction.hh
+++ b/src/GlueXDetectorConstruction.hh
@@ -21,6 +21,7 @@
 #include <G4ThreeVector.hh>
 #include <GlueXMagneticField.hh>
 #include <HddsG4Builder.hh>
+#include <HddsGeometryXML.hh>
 
 class G4Box;
 class G4LogicalVolume;
@@ -70,6 +71,9 @@ class GlueXDetectorConstruction : public G4VUserDetectorConstruction
 
      static G4Mutex fMutex;
      static std::list<GlueXDetectorConstruction*> fInstance;
+
+  protected:
+     HddsGeometryXML *fGeometryXML;
 };
 
 class GlueXParallelWorld : public G4VUserParallelWorld

--- a/src/HddsGeometryXML.hh
+++ b/src/HddsGeometryXML.hh
@@ -1,0 +1,28 @@
+//
+// HddsGeometry - class header
+//
+// author: richard.t.jones at uconn.edu
+// version: november 21, 2017
+//
+// In the context of the Geant4 event-level multithreading model,
+// this class is "shared", ie. has no thread-local state.
+
+#ifndef _HDDSGEOMETRYXML_
+#define _HDDSGEOMETRYXML_
+
+#include <JANA/JGeometryXML.h>
+
+class HddsGeometryXML : public jana::JGeometryXML
+{
+ public:
+   HddsGeometryXML(std::string url, int run) : jana::JGeometryXML(url, run, "") {}
+   ~HddsGeometryXML() {}
+
+   DOMDocument *getDocument() { return doc; }
+
+ private:
+   HddsGeometryXML(const HddsGeometryXML &src);
+   HddsGeometryXML &operator=(const HddsGeometryXML &src);
+};
+
+#endif


### PR DESCRIPTION
   - add support for the ccdb://GEOMETRY style url in JANA_GEOMETRY_URL
     in addition to the xmlfile:// style. The run number for geometry
     lookup is the simulation run number. The variation is taken from
     JANA_CALIB_CONTEXT, or mc_default if not defined. This allows a
     consistent simulation + analysis to take place within a single
     shell session without changing the environment.

* src/HddsGeometryXML.hh [rtj]
   - new class added to hdgeant4 called HddsGeometryXML, subclass of
     jana::JGeometryXML, to get access to hdds geometry that jana
     fetches and parses from ccdb.