### PR TITLE
Add search of sqlite3 and SQLiteCpp libraries.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -66,6 +66,7 @@ DANALIBS = -L$(HALLD_HOME)/$(BMS_OSNAME)/lib -lHDGEOMETRY -lDANA \
            -lFDC -lFMWPC -lHDDM -lPAIR_SPECTROMETER -lPID -lRF \
            -lSTART_COUNTER -lTAGGER -lTOF -lTPOL -lTRACKING \
            -lTRIGGER -lDAQ -lTTAB -lEVENTSTORE -lKINFITTER -lTAC \
+           -L$(SQLITECPP_HOME)/lib -lSQLiteCpp -lsqlite3 \
            -lxstream -lbz2 -lz \
            -L/usr/lib64/mysql -lmysqlclient\
            -L$(JANA_HOME)/lib -lJANA \

--- a/GNUmakefile.OSX
+++ b/GNUmakefile.OSX
@@ -65,6 +65,7 @@ DANALIBS = -L$(HALLD_HOME)/$(BMS_OSNAME)/lib -lHDGEOMETRY -lDANA \
            -lFDC -lFMWPC -lHDDM -lPAIR_SPECTROMETER -lPID -lRF \
            -lSTART_COUNTER -lTAGGER -lTOF -lTPOL -lTRACKING \
            -lTRIGGER -lDAQ -lTTAB -lEVENTSTORE -lKINFITTER -lTAC \
+           -L$(SQLITECPP_HOME)/lib -lSQLiteCpp -lsqlite3 \
            -lxstream -lbz2 -lz \
            $(shell mysql_config --libs) \
            -L$(JANA_HOME)/lib -lJANA \


### PR DESCRIPTION
Uses the new SQLiteCpp library to support RCDB reading of SQLite files. Changes needed to GNUmakefile to use the new scheme. Change also made to GNUmakefile.OSX but not tested.