### PR TITLE
* GlueXPhotonBeamGenerator.cc, .hh [rtj]

### DIFF
--- a/src/GlueXPhotonBeamGenerator.hh
+++ b/src/GlueXPhotonBeamGenerator.hh
@@ -13,6 +13,7 @@
 #define GlueXPhotonBeamGenerator_H
 
 #include <G4VPrimaryGenerator.hh>
+#include <G4GenericMessenger.hh>
 #include <CobremsGeneration.hh>
 #include <ImportanceSampler.hh>
 #include <GlueXPseudoDetectorTAG.hh>
@@ -50,6 +51,12 @@ class GlueXPhotonBeamGenerator: public G4VPrimaryGenerator
 
    void prepareImportanceSamplingPDFs();
 
+   static int fForceFixedPolarization;
+   static double fFixedPolarization;
+   static double fFixedPolarization_phi;
+
+   G4GenericMessenger *fMessenger;
+
  public:
    static void setBeamDiameter(double D) {
       fBeamDiameter = D;
@@ -70,6 +77,14 @@ class GlueXPhotonBeamGenerator: public G4VPrimaryGenerator
    }
    static double getBeamStartZ() {
       return fBeamStartZ;
+   }
+   void enableFixedPolarization(double polar, double phi_deg) {
+      fFixedPolarization = polar;
+      fFixedPolarization_phi = phi_deg * M_PI/180;
+      fForceFixedPolarization = true;
+   }
+   void disableFixedPolarization() {
+      fForceFixedPolarization = false;
    }
 
  private:


### PR DESCRIPTION
   - add a new user command /PhotonBeam/enableFixedPolarization <p> <angle>
     to force all beam photons to a common value of polarization <p> at
     azimuthal angle <angle> (degrees) from the horizontal. For PARA, set
     <angle> to 0, for PERP set it to 90. To turn off this forced value
     for the polarization and allow the generator to set the polarization
     according to the physics of coherent bremsstralhung, you can use
     /PhotonBeam/disableFixedPolarization or just leave it as the default
     which is to disable the forcing.