### PR TITLE
- add print statements that empirically fix a race condition when

### DIFF
--- a/src/GlueXPhotonBeamGenerator.cc
+++ b/src/GlueXPhotonBeamGenerator.cc
@@ -116,6 +116,7 @@ GlueXPhotonBeamGenerator::GlueXPhotonBeamGenerator(CobremsGeneration *gen)
                              &GlueXPhotonBeamGenerator::disableFixedPolarization,
        "Tell the photon beam generator not to force a fixed polarization\n"
        " on beam photons created by the simulation.");
+   std::cout << "GlueXPhotonBeamGenerator initialization complete." << std::endl;
 }
 
 GlueXPhotonBeamGenerator::~GlueXPhotonBeamGenerator()

--- a/src/hdgeant4.cc
+++ b/src/hdgeant4.cc
@@ -165,8 +165,9 @@ int main(int argc,char** argv)
    runManager.SetUserInitialization(userinit);
 
    // Initialize G4 kernel
+   std::cout << "Initializing the Geant4 kernel..." << std::endl;
    runManager.Initialize();
-
+   
    // Initialize graphics (option -v)
    G4VisManager* visManager = 0;
    if (use_visualization) {


### PR DESCRIPTION
  running with multithreading, which prevents the UI from seeing
  user commands added during the initialization phase. [rtj]