### PR TITLE
- the following updates were required to ALL of our hits classes and the

### DIFF
--- a/src/GlueXHitBCALcell.cc
+++ b/src/GlueXHitBCALcell.cc
@@ -15,6 +15,14 @@ GlueXHitBCALcell::GlueXHitBCALcell(G4int module, G4int layer, G4int sector)
    sector_(sector)
 {}
 
+GlueXHitBCALcell::GlueXHitBCALcell(const GlueXHitBCALcell &src)
+{
+   module_ = src.module_;
+   layer_ = src.layer_;
+   sector_ = src.sector_;
+   hits = src.hits;
+}
+
 int GlueXHitBCALcell::operator==(const GlueXHitBCALcell &right) const
 {
    if (module_ !=  right.module_ || layer_ != right.layer_ || 

--- a/src/GlueXHitBCALcell.hh
+++ b/src/GlueXHitBCALcell.hh
@@ -19,7 +19,9 @@
 class GlueXHitBCALcell : public G4VHit
 {
  public:
+   GlueXHitBCALcell() {}
    GlueXHitBCALcell(G4int module, G4int layer, G4int sector);
+   GlueXHitBCALcell(const GlueXHitBCALcell &src);
    int operator==(const GlueXHitBCALcell &right) const;
    GlueXHitBCALcell &operator+=(const GlueXHitBCALcell &right);
 

--- a/src/GlueXHitBCALpoint.cc
+++ b/src/GlueXHitBCALpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitBCALpoint>* GlueXHitBCALpointAllocator = 0;
 
+GlueXHitBCALpoint::GlueXHitBCALpoint(const GlueXHitBCALpoint &src)
+{
+   E_GeV = src.E_GeV;
+   phi_rad = src.phi_rad;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   r_cm = src.r_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitBCALpoint::operator==(const GlueXHitBCALpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitBCALpoint.hh
+++ b/src/GlueXHitBCALpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitBCALpoint : public G4VHit
 {
  public:
    GlueXHitBCALpoint() {}
+   GlueXHitBCALpoint(const GlueXHitBCALpoint &src);
    int operator==(const GlueXHitBCALpoint &right) const;
    GlueXHitBCALpoint &operator+=(const GlueXHitBCALpoint &right);
 

--- a/src/GlueXHitCCALblock.cc
+++ b/src/GlueXHitCCALblock.cc
@@ -14,6 +14,13 @@ GlueXHitCCALblock::GlueXHitCCALblock(G4int column, G4int row)
    row_(row)
 {}
 
+GlueXHitCCALblock::GlueXHitCCALblock(const GlueXHitCCALblock &src)
+{
+   column_ = src.column_;
+   row_ = src.row_;
+   hits = src.hits;
+}
+
 int GlueXHitCCALblock::operator==(const GlueXHitCCALblock &right) const
 {
    if (column_ !=  right.column_ || row_ != right.row_) {

--- a/src/GlueXHitCCALblock.hh
+++ b/src/GlueXHitCCALblock.hh
@@ -19,7 +19,9 @@
 class GlueXHitCCALblock : public G4VHit
 {
  public:
+   GlueXHitCCALblock() {}
    GlueXHitCCALblock(G4int column, G4int row);
+   GlueXHitCCALblock(const GlueXHitCCALblock &src);
    int operator==(const GlueXHitCCALblock &right) const;
    GlueXHitCCALblock &operator+=(const GlueXHitCCALblock &right);
 

--- a/src/GlueXHitCCALpoint.cc
+++ b/src/GlueXHitCCALpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitCCALpoint>* GlueXHitCCALpointAllocator = 0;
 
+GlueXHitCCALpoint::GlueXHitCCALpoint(const GlueXHitCCALpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitCCALpoint::operator==(const GlueXHitCCALpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitCCALpoint.hh
+++ b/src/GlueXHitCCALpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitCCALpoint : public G4VHit
 {
  public:
    GlueXHitCCALpoint() {}
+   GlueXHitCCALpoint(const GlueXHitCCALpoint &src);
    int operator==(const GlueXHitCCALpoint &right) const;
    GlueXHitCCALpoint &operator+=(const GlueXHitCCALpoint &right);
 

--- a/src/GlueXHitCDCpoint.cc
+++ b/src/GlueXHitCDCpoint.cc
@@ -8,6 +8,25 @@
 
 G4ThreadLocal G4Allocator<GlueXHitCDCpoint>* GlueXHitCDCpointAllocator = 0;
 
+GlueXHitCDCpoint::GlueXHitCDCpoint(const GlueXHitCDCpoint &src)
+{
+   dEdx_GeV_cm = src.dEdx_GeV_cm;
+   dradius_cm = src.dradius_cm;
+   phi_rad = src.phi_rad;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   r_cm = src.r_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+   sector_ = src.sector_;
+   ring_ = src.ring_;
+}
+
 int GlueXHitCDCpoint::operator==(const GlueXHitCDCpoint &right) const
 {
    if (dEdx_GeV_cm != right.dEdx_GeV_cm ||

--- a/src/GlueXHitCDCpoint.hh
+++ b/src/GlueXHitCDCpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitCDCpoint : public G4VHit
 {
  public:
    GlueXHitCDCpoint() {}
+   GlueXHitCDCpoint(const GlueXHitCDCpoint &src);
    int operator==(const GlueXHitCDCpoint &right) const;
    GlueXHitCDCpoint &operator+=(const GlueXHitCDCpoint &right);
 

--- a/src/GlueXHitCDCstraw.cc
+++ b/src/GlueXHitCDCstraw.cc
@@ -15,6 +15,13 @@ GlueXHitCDCstraw::GlueXHitCDCstraw(G4int ring, G4int sector)
    sector_(sector)
 {}
 
+GlueXHitCDCstraw::GlueXHitCDCstraw(const GlueXHitCDCstraw &src)
+{
+   ring_ = src.ring_;
+   sector_ = src.sector_;
+   hits = src.hits;
+}
+
 int GlueXHitCDCstraw::operator==(const GlueXHitCDCstraw &right) const
 {
    if (ring_ != right.ring_  || sector_ !=  right.sector_)

--- a/src/GlueXHitCDCstraw.hh
+++ b/src/GlueXHitCDCstraw.hh
@@ -20,7 +20,9 @@
 class GlueXHitCDCstraw : public G4VHit
 {
  public:
+   GlueXHitCDCstraw() {}
    GlueXHitCDCstraw(G4int ring, G4int sector);
+   GlueXHitCDCstraw(const GlueXHitCDCstraw &src);
    int operator==(const GlueXHitCDCstraw &right) const;
    GlueXHitCDCstraw &operator+=(const GlueXHitCDCstraw &right);
 

--- a/src/GlueXHitCEREpoint.cc
+++ b/src/GlueXHitCEREpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitCEREpoint>* GlueXHitCEREpointAllocator = 0;
 
+GlueXHitCEREpoint::GlueXHitCEREpoint(const GlueXHitCEREpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitCEREpoint::operator==(const GlueXHitCEREpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitCEREpoint.hh
+++ b/src/GlueXHitCEREpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitCEREpoint : public G4VHit
 {
  public:
    GlueXHitCEREpoint() {}
+   GlueXHitCEREpoint(const GlueXHitCEREpoint &src);
    int operator==(const GlueXHitCEREpoint &right) const;
    GlueXHitCEREpoint &operator+=(const GlueXHitCEREpoint &right);
 

--- a/src/GlueXHitCEREtube.cc
+++ b/src/GlueXHitCEREtube.cc
@@ -13,6 +13,12 @@ GlueXHitCEREtube::GlueXHitCEREtube(G4int sector)
    sector_(sector)
 {}
 
+GlueXHitCEREtube::GlueXHitCEREtube(const GlueXHitCEREtube &src)
+{
+   sector_ = src.sector_;
+   hits = src.hits;
+}
+
 int GlueXHitCEREtube::operator==(const GlueXHitCEREtube &right) const
 {
    if (sector_ !=  right.sector_)

--- a/src/GlueXHitCEREtube.hh
+++ b/src/GlueXHitCEREtube.hh
@@ -19,7 +19,9 @@
 class GlueXHitCEREtube : public G4VHit
 {
  public:
+   GlueXHitCEREtube() {}
    GlueXHitCEREtube(G4int sector);
+   GlueXHitCEREtube(const GlueXHitCEREtube &src);
    int operator==(const GlueXHitCEREtube &right) const;
    GlueXHitCEREtube &operator+=(const GlueXHitCEREtube &right);
 

--- a/src/GlueXHitDIRCBar.cc
+++ b/src/GlueXHitDIRCBar.cc
@@ -8,8 +8,19 @@
 
 G4ThreadLocal G4Allocator<GlueXHitDIRCBar>* GlueXHitDIRCBarAllocator = 0;
 
-GlueXHitDIRCBar::GlueXHitDIRCBar():G4VHit()
+GlueXHitDIRCBar::GlueXHitDIRCBar(const GlueXHitDIRCBar &src)
 {
+  E_GeV = src.E_GeV;
+  t_ns = src.t_ns;
+  x_cm = src.x_cm;
+  y_cm = src.y_cm;
+  z_cm = src.z_cm;
+  px_GeV = src.px_GeV;
+  py_GeV = src.py_GeV;
+  pz_GeV = src.pz_GeV;
+  pdg = src.pdg;
+  bar = src.bar;
+  track = src.track;
 }
 
 void GlueXHitDIRCBar::Draw() const

--- a/src/GlueXHitDIRCBar.hh
+++ b/src/GlueXHitDIRCBar.hh
@@ -14,7 +14,8 @@
 class GlueXHitDIRCBar : public G4VHit
 {
 public:
-  GlueXHitDIRCBar();
+  GlueXHitDIRCBar() {}
+  GlueXHitDIRCBar(const GlueXHitDIRCBar &src);
 
   void *operator new(size_t);
   void operator delete(void *aHit);

--- a/src/GlueXHitDIRCPmt.cc
+++ b/src/GlueXHitDIRCPmt.cc
@@ -9,9 +9,16 @@
 
 G4ThreadLocal G4Allocator<GlueXHitDIRCPmt>* GlueXHitDIRCPmtAllocator = 0;
 
-GlueXHitDIRCPmt::GlueXHitDIRCPmt()
-  : G4VHit()
-{}
+GlueXHitDIRCPmt::GlueXHitDIRCPmt(const GlueXHitDIRCPmt &src)
+{
+  E_GeV = src.E_GeV;
+  t_ns = src.t_ns;
+  x_cm = src.x_cm;
+  y_cm = src.y_cm;
+  z_cm = src.z_cm;
+  ch = src.ch;
+  key_bar = src.key_bar;
+}
 
 void GlueXHitDIRCPmt::Draw() const
 {

--- a/src/GlueXHitDIRCPmt.hh
+++ b/src/GlueXHitDIRCPmt.hh
@@ -14,7 +14,8 @@
 class GlueXHitDIRCPmt : public G4VHit
 {
 public:
-  GlueXHitDIRCPmt();
+  GlueXHitDIRCPmt() {}
+  GlueXHitDIRCPmt(const GlueXHitDIRCPmt &src);
   
   void *operator new(size_t);
   void operator delete(void *aHit);

--- a/src/GlueXHitDIRCflash.cc
+++ b/src/GlueXHitDIRCflash.cc
@@ -26,6 +26,12 @@ GlueXHitDIRCflash::GlueXHitDIRCflash(G4int bar)
    bar_(bar)
 {}
 
+GlueXHitDIRCflash::GlueXHitDIRCflash(const GlueXHitDIRCflash &src)
+{
+   bar_ = src.bar_;
+   hits = src.hits;
+}
+
 int GlueXHitDIRCflash::operator==(const GlueXHitDIRCflash &right) const
 {
    if (bar_ !=  right.bar_)

--- a/src/GlueXHitDIRCflash.hh
+++ b/src/GlueXHitDIRCflash.hh
@@ -33,6 +33,7 @@ class GlueXHitDIRCflash : public G4VHit
 {
  public:
    GlueXHitDIRCflash(G4int bar=0);
+   GlueXHitDIRCflash(const GlueXHitDIRCflash &src);
    int operator==(const GlueXHitDIRCflash &right) const;
    GlueXHitDIRCflash &operator+=(const GlueXHitDIRCflash &right);
 

--- a/src/GlueXHitDIRCpoint.cc
+++ b/src/GlueXHitDIRCpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitDIRCpoint>* GlueXHitDIRCpointAllocator = 0;
 
+GlueXHitDIRCpoint::GlueXHitDIRCpoint(const GlueXHitDIRCpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitDIRCpoint::operator==(const GlueXHitDIRCpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitDIRCpoint.hh
+++ b/src/GlueXHitDIRCpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitDIRCpoint : public G4VHit
 {
  public:
    GlueXHitDIRCpoint() {}
+   GlueXHitDIRCpoint(const GlueXHitDIRCpoint &src);
    int operator==(const GlueXHitDIRCpoint &right) const;
    GlueXHitDIRCpoint &operator+=(const GlueXHitDIRCpoint &right);
 

--- a/src/GlueXHitFCALblock.cc
+++ b/src/GlueXHitFCALblock.cc
@@ -14,6 +14,13 @@ GlueXHitFCALblock::GlueXHitFCALblock(G4int column, G4int row)
    row_(row)
 {}
 
+GlueXHitFCALblock::GlueXHitFCALblock(const GlueXHitFCALblock &src)
+{
+   column_ = src.column_;
+   row_ = src.row_;
+   hits = src.hits;
+}
+
 int GlueXHitFCALblock::operator==(const GlueXHitFCALblock &right) const
 {
    if (column_ !=  right.column_ || row_ != right.row_) {

--- a/src/GlueXHitFCALblock.hh
+++ b/src/GlueXHitFCALblock.hh
@@ -19,7 +19,9 @@
 class GlueXHitFCALblock : public G4VHit
 {
  public:
+   GlueXHitFCALblock() {}
    GlueXHitFCALblock(G4int column, G4int row);
+   GlueXHitFCALblock(const GlueXHitFCALblock &src);
    int operator==(const GlueXHitFCALblock &right) const;
    GlueXHitFCALblock &operator+=(const GlueXHitFCALblock &right);
 

--- a/src/GlueXHitFCALpoint.cc
+++ b/src/GlueXHitFCALpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitFCALpoint>* GlueXHitFCALpointAllocator = 0;
 
+GlueXHitFCALpoint::GlueXHitFCALpoint(const GlueXHitFCALpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitFCALpoint::operator==(const GlueXHitFCALpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitFCALpoint.hh
+++ b/src/GlueXHitFCALpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitFCALpoint : public G4VHit
 {
  public:
    GlueXHitFCALpoint() {}
+   GlueXHitFCALpoint(const GlueXHitFCALpoint &src);
    int operator==(const GlueXHitFCALpoint &right) const;
    GlueXHitFCALpoint &operator+=(const GlueXHitFCALpoint &right);
 

--- a/src/GlueXHitFDCcathode.cc
+++ b/src/GlueXHitFDCcathode.cc
@@ -15,6 +15,14 @@ GlueXHitFDCcathode::GlueXHitFDCcathode(G4int chamber, G4int plane, G4int strip)
    strip_(strip)
 {}
 
+GlueXHitFDCcathode::GlueXHitFDCcathode(const GlueXHitFDCcathode &src)
+{
+   chamber_ = src.chamber_;
+   plane_ = src.plane_;
+   strip_ = src.strip_;
+   hits = src.hits;
+}
+
 int GlueXHitFDCcathode::operator==(const GlueXHitFDCcathode &right) const
 {
    if (chamber_ != right.chamber_  ||

--- a/src/GlueXHitFDCcathode.hh
+++ b/src/GlueXHitFDCcathode.hh
@@ -19,7 +19,9 @@
 class GlueXHitFDCcathode : public G4VHit
 {
  public:
+   GlueXHitFDCcathode() {}
    GlueXHitFDCcathode(G4int chamber, G4int plane, G4int strip);
+   GlueXHitFDCcathode(const GlueXHitFDCcathode &src);
    int operator==(const GlueXHitFDCcathode &right) const;
    GlueXHitFDCcathode &operator+=(const GlueXHitFDCcathode &right);
 

--- a/src/GlueXHitFDCpoint.cc
+++ b/src/GlueXHitFDCpoint.cc
@@ -13,6 +13,25 @@ GlueXHitFDCpoint::GlueXHitFDCpoint(G4int chamber)
    chamber_(chamber)
 {}
 
+GlueXHitFDCpoint::GlueXHitFDCpoint(const GlueXHitFDCpoint &src)
+{
+   chamber_ = src.chamber_;
+   E_GeV = src.E_GeV;
+   dEdx_GeV_cm = src.dEdx_GeV_cm;
+   dradius_cm = src.dradius_cm;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitFDCpoint::operator==(const GlueXHitFDCpoint &right) const
 {
    if (E_GeV          != right.E_GeV       ||

--- a/src/GlueXHitFDCpoint.hh
+++ b/src/GlueXHitFDCpoint.hh
@@ -19,7 +19,9 @@
 class GlueXHitFDCpoint : public G4VHit
 {
  public:
+   GlueXHitFDCpoint() {}
    GlueXHitFDCpoint(int chamber);
+   GlueXHitFDCpoint(const GlueXHitFDCpoint &src);
    int operator==(const GlueXHitFDCpoint &right) const;
    GlueXHitFDCpoint &operator+=(const GlueXHitFDCpoint &right);
 

--- a/src/GlueXHitFDCwire.cc
+++ b/src/GlueXHitFDCwire.cc
@@ -14,6 +14,13 @@ GlueXHitFDCwire::GlueXHitFDCwire(G4int chamber, G4int wire)
    wire_(wire)
 {}
 
+GlueXHitFDCwire::GlueXHitFDCwire(const GlueXHitFDCwire &src)
+{
+   chamber_ = src.chamber_;
+   wire_ = src.wire_;
+   hits = src.hits;
+}
+
 int GlueXHitFDCwire::operator==(const GlueXHitFDCwire &right) const
 {
    if (chamber_ != right.chamber_  || wire_ !=  right.wire_)

--- a/src/GlueXHitFDCwire.hh
+++ b/src/GlueXHitFDCwire.hh
@@ -20,7 +20,9 @@
 class GlueXHitFDCwire : public G4VHit
 {
  public:
+   GlueXHitFDCwire() {}
    GlueXHitFDCwire(G4int chamber, G4int wire);
+   GlueXHitFDCwire(const GlueXHitFDCwire &src);
    int operator==(const GlueXHitFDCwire &right) const;
    GlueXHitFDCwire &operator+=(const GlueXHitFDCwire &right);
 

--- a/src/GlueXHitFMWPCpoint.cc
+++ b/src/GlueXHitFMWPCpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitFMWPCpoint>* GlueXHitFMWPCpointAllocator = 0;
 
+GlueXHitFMWPCpoint::GlueXHitFMWPCpoint(const GlueXHitFMWPCpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitFMWPCpoint::operator==(const GlueXHitFMWPCpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitFMWPCpoint.hh
+++ b/src/GlueXHitFMWPCpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitFMWPCpoint : public G4VHit
 {
  public:
    GlueXHitFMWPCpoint() {}
+   GlueXHitFMWPCpoint(const GlueXHitFMWPCpoint &src);
    int operator==(const GlueXHitFMWPCpoint &right) const;
    GlueXHitFMWPCpoint &operator+=(const GlueXHitFMWPCpoint &right);
 

--- a/src/GlueXHitFMWPCwire.cc
+++ b/src/GlueXHitFMWPCwire.cc
@@ -14,6 +14,13 @@ GlueXHitFMWPCwire::GlueXHitFMWPCwire(G4int layer, G4int wire)
    wire_(wire)
 {}
 
+GlueXHitFMWPCwire::GlueXHitFMWPCwire(const GlueXHitFMWPCwire &src)
+{
+   layer_ = src.layer_;
+   wire_ = src.wire_;
+   hits = src.hits;
+}
+
 int GlueXHitFMWPCwire::operator==(const GlueXHitFMWPCwire &right) const
 {
    if (layer_ !=  right.layer_ || wire_ != right.wire_)

--- a/src/GlueXHitFMWPCwire.hh
+++ b/src/GlueXHitFMWPCwire.hh
@@ -19,7 +19,9 @@
 class GlueXHitFMWPCwire : public G4VHit
 {
  public:
+   GlueXHitFMWPCwire() {}
    GlueXHitFMWPCwire(G4int layer, G4int wire);
+   GlueXHitFMWPCwire(const GlueXHitFMWPCwire &src);
    int operator==(const GlueXHitFMWPCwire &right) const;
    GlueXHitFMWPCwire &operator+=(const GlueXHitFMWPCwire &right);
 

--- a/src/GlueXHitFTOFbar.cc
+++ b/src/GlueXHitFTOFbar.cc
@@ -14,6 +14,13 @@ GlueXHitFTOFbar::GlueXHitFTOFbar(G4int plane, G4int bar)
    bar_(bar)
 {}
 
+GlueXHitFTOFbar::GlueXHitFTOFbar(const GlueXHitFTOFbar &src)
+{
+   plane_ = src.plane_;
+   bar_ = src.bar_;
+   hits = src.hits;
+}
+
 int GlueXHitFTOFbar::operator==(const GlueXHitFTOFbar &right) const
 {
    if (plane_ !=  right.plane_ || bar_ != right.bar_ )

--- a/src/GlueXHitFTOFbar.hh
+++ b/src/GlueXHitFTOFbar.hh
@@ -19,7 +19,9 @@
 class GlueXHitFTOFbar : public G4VHit
 {
  public:
+   GlueXHitFTOFbar() {}
    GlueXHitFTOFbar(G4int plane, G4int bar);
+   GlueXHitFTOFbar(const GlueXHitFTOFbar &src);
    int operator==(const GlueXHitFTOFbar &right) const;
    GlueXHitFTOFbar &operator+=(const GlueXHitFTOFbar &right);
 

--- a/src/GlueXHitFTOFpoint.cc
+++ b/src/GlueXHitFTOFpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitFTOFpoint>* GlueXHitFTOFpointAllocator = 0;
 
+GlueXHitFTOFpoint::GlueXHitFTOFpoint(const GlueXHitFTOFpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitFTOFpoint::operator==(const GlueXHitFTOFpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitFTOFpoint.hh
+++ b/src/GlueXHitFTOFpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitFTOFpoint : public G4VHit
 {
  public:
    GlueXHitFTOFpoint() {}
+   GlueXHitFTOFpoint(const GlueXHitFTOFpoint &src);
    int operator==(const GlueXHitFTOFpoint &right) const;
    GlueXHitFTOFpoint &operator+=(const GlueXHitFTOFpoint &right);
 

--- a/src/GlueXHitGCALblock.cc
+++ b/src/GlueXHitGCALblock.cc
@@ -13,6 +13,12 @@ GlueXHitGCALblock::GlueXHitGCALblock(G4int module)
    module_(module)
 {}
 
+GlueXHitGCALblock::GlueXHitGCALblock(const GlueXHitGCALblock &src)
+{
+   module_ = src.module_;
+   hits = src.hits;
+}
+
 int GlueXHitGCALblock::operator==(const GlueXHitGCALblock &right) const
 {
    if (module_ !=  right.module_) {

--- a/src/GlueXHitGCALblock.hh
+++ b/src/GlueXHitGCALblock.hh
@@ -19,7 +19,9 @@
 class GlueXHitGCALblock : public G4VHit
 {
  public:
+   GlueXHitGCALblock() {}
    GlueXHitGCALblock(G4int module);
+   GlueXHitGCALblock(const GlueXHitGCALblock &src);
    int operator==(const GlueXHitGCALblock &right) const;
    GlueXHitGCALblock &operator+=(const GlueXHitGCALblock &right);
 

--- a/src/GlueXHitGCALpoint.cc
+++ b/src/GlueXHitGCALpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitGCALpoint>* GlueXHitGCALpointAllocator = 0;
 
+GlueXHitGCALpoint::GlueXHitGCALpoint(const GlueXHitGCALpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   r_cm = src.r_cm;
+   phi_rad = src.phi_rad;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitGCALpoint::operator==(const GlueXHitGCALpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitGCALpoint.hh
+++ b/src/GlueXHitGCALpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitGCALpoint : public G4VHit
 {
  public:
    GlueXHitGCALpoint() {}
+   GlueXHitGCALpoint(const GlueXHitGCALpoint &src);
    int operator==(const GlueXHitGCALpoint &right) const;
    GlueXHitGCALpoint &operator+=(const GlueXHitGCALpoint &right);
 

--- a/src/GlueXHitPSCpaddle.cc
+++ b/src/GlueXHitPSCpaddle.cc
@@ -14,6 +14,13 @@ GlueXHitPSCpaddle::GlueXHitPSCpaddle(G4int arm, G4int module)
    module_(module)
 {}
 
+GlueXHitPSCpaddle::GlueXHitPSCpaddle(const GlueXHitPSCpaddle &src)
+{
+   arm_ = src.arm_;
+   module_ = src.module_;
+   hits = src.hits;
+}
+
 int GlueXHitPSCpaddle::operator==(const GlueXHitPSCpaddle &right) const
 {
    if (module_ !=  right.module_ || arm_ != right.arm_)

--- a/src/GlueXHitPSCpaddle.hh
+++ b/src/GlueXHitPSCpaddle.hh
@@ -19,7 +19,9 @@
 class GlueXHitPSCpaddle : public G4VHit
 {
  public:
+   GlueXHitPSCpaddle() {}
    GlueXHitPSCpaddle(G4int arm, G4int module);
+   GlueXHitPSCpaddle(const GlueXHitPSCpaddle &src);
    int operator==(const GlueXHitPSCpaddle &right) const;
    GlueXHitPSCpaddle &operator+=(const GlueXHitPSCpaddle &right);
 

--- a/src/GlueXHitPSCpoint.cc
+++ b/src/GlueXHitPSCpoint.cc
@@ -8,6 +8,25 @@
 
 G4ThreadLocal G4Allocator<GlueXHitPSCpoint>* GlueXHitPSCpointAllocator = 0;
 
+GlueXHitPSCpoint::GlueXHitPSCpoint(const GlueXHitPSCpoint &src)
+{
+   arm_ = src.arm_;
+   module_ = src.module_;
+   E_GeV = src.E_GeV;
+   dEdx_GeV_cm = src.dEdx_GeV_cm;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitPSCpoint::operator==(const GlueXHitPSCpoint &right) const
 {
    if (arm_        != right.arm_        ||

--- a/src/GlueXHitPSCpoint.hh
+++ b/src/GlueXHitPSCpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitPSCpoint : public G4VHit
 {
  public:
    GlueXHitPSCpoint() {}
+   GlueXHitPSCpoint(const GlueXHitPSCpoint &src);
    int operator==(const GlueXHitPSCpoint &right) const;
    GlueXHitPSCpoint &operator+=(const GlueXHitPSCpoint &right);
 

--- a/src/GlueXHitPSpoint.cc
+++ b/src/GlueXHitPSpoint.cc
@@ -8,6 +8,25 @@
 
 G4ThreadLocal G4Allocator<GlueXHitPSpoint>* GlueXHitPSpointAllocator = 0;
 
+GlueXHitPSpoint::GlueXHitPSpoint(const GlueXHitPSpoint &src)
+{
+   arm_ = src.arm_;
+   column_ = src.column_;
+   E_GeV = src.E_GeV;
+   dEdx_GeV_cm = src.dEdx_GeV_cm;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitPSpoint::operator==(const GlueXHitPSpoint &right) const
 {
    if (arm_        != right.arm_        ||

--- a/src/GlueXHitPSpoint.hh
+++ b/src/GlueXHitPSpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitPSpoint : public G4VHit
 {
  public:
    GlueXHitPSpoint() {}
+   GlueXHitPSpoint(const GlueXHitPSpoint &src);
    int operator==(const GlueXHitPSpoint &right) const;
    GlueXHitPSpoint &operator+=(const GlueXHitPSpoint &right);
 

--- a/src/GlueXHitPStile.cc
+++ b/src/GlueXHitPStile.cc
@@ -14,6 +14,13 @@ GlueXHitPStile::GlueXHitPStile(G4int arm, G4int column)
    column_(column)
 {}
 
+GlueXHitPStile::GlueXHitPStile(const GlueXHitPStile &src)
+{
+   arm_ = src.arm_;
+   column_ = src.column_;
+   hits = src.hits;
+}
+
 int GlueXHitPStile::operator==(const GlueXHitPStile &right) const
 {
    if (arm_ !=  right.arm_ || column_ != right.column_)

--- a/src/GlueXHitPStile.hh
+++ b/src/GlueXHitPStile.hh
@@ -19,7 +19,9 @@
 class GlueXHitPStile : public G4VHit
 {
  public:
+   GlueXHitPStile() {}
    GlueXHitPStile(G4int arm, G4int column);
+   GlueXHitPStile(const GlueXHitPStile &src);
    int operator==(const GlueXHitPStile &right) const;
    GlueXHitPStile &operator+=(const GlueXHitPStile &right);
 

--- a/src/GlueXHitSTCpaddle.cc
+++ b/src/GlueXHitSTCpaddle.cc
@@ -13,6 +13,12 @@ GlueXHitSTCpaddle::GlueXHitSTCpaddle(G4int sector)
    sector_(sector)
 {}
 
+GlueXHitSTCpaddle::GlueXHitSTCpaddle(const GlueXHitSTCpaddle &src)
+{
+   sector_ = src.sector_;
+   hits = src.hits;
+}
+
 int GlueXHitSTCpaddle::operator==(const GlueXHitSTCpaddle &right) const
 {
    if (sector_ !=  right.sector_)

--- a/src/GlueXHitSTCpaddle.hh
+++ b/src/GlueXHitSTCpaddle.hh
@@ -19,7 +19,9 @@
 class GlueXHitSTCpaddle : public G4VHit
 {
  public:
+   GlueXHitSTCpaddle() {}
    GlueXHitSTCpaddle(G4int sector);
+   GlueXHitSTCpaddle(const GlueXHitSTCpaddle &src);
    int operator==(const GlueXHitSTCpaddle &right) const;
    GlueXHitSTCpaddle &operator+=(const GlueXHitSTCpaddle &right);
 

--- a/src/GlueXHitSTCpoint.cc
+++ b/src/GlueXHitSTCpoint.cc
@@ -8,6 +8,24 @@
 
 G4ThreadLocal G4Allocator<GlueXHitSTCpoint>* GlueXHitSTCpointAllocator = 0;
 
+GlueXHitSTCpoint::GlueXHitSTCpoint(const GlueXHitSTCpoint &src)
+{
+   E_GeV = src.E_GeV;
+   dEdx_GeV_cm = src.dEdx_GeV_cm;
+   phi_rad = src.phi_rad;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   r_cm = src.r_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   sector_ = src.sector_;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitSTCpoint::operator==(const GlueXHitSTCpoint &right) const
 {
    if (E_GeV       != right.E_GeV       ||

--- a/src/GlueXHitSTCpoint.hh
+++ b/src/GlueXHitSTCpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitSTCpoint : public G4VHit
 {
  public:
    GlueXHitSTCpoint() {}
+   GlueXHitSTCpoint(const GlueXHitSTCpoint &src);
    int operator==(const GlueXHitSTCpoint &right) const;
    GlueXHitSTCpoint &operator+=(const GlueXHitSTCpoint &right);
 

--- a/src/GlueXHitTPOLpoint.cc
+++ b/src/GlueXHitTPOLpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitTPOLpoint>* GlueXHitTPOLpointAllocator = 0;
 
+GlueXHitTPOLpoint::GlueXHitTPOLpoint(const GlueXHitTPOLpoint &src)
+{
+   E_GeV = src.E_GeV;
+   dEdx_GeV_cm = src.dEdx_GeV_cm;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   phi_rad = src.phi_rad;
+   r_cm = src.r_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitTPOLpoint::operator==(const GlueXHitTPOLpoint &right) const
 {
    if (E_GeV       != right.E_GeV       ||

--- a/src/GlueXHitTPOLpoint.hh
+++ b/src/GlueXHitTPOLpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitTPOLpoint : public G4VHit
 {
  public:
    GlueXHitTPOLpoint() {}
+   GlueXHitTPOLpoint(const GlueXHitTPOLpoint &src);
    int operator==(const GlueXHitTPOLpoint &right) const;
    GlueXHitTPOLpoint &operator+=(const GlueXHitTPOLpoint &right);
 

--- a/src/GlueXHitTPOLwedge.cc
+++ b/src/GlueXHitTPOLwedge.cc
@@ -13,6 +13,14 @@ GlueXHitTPOLwedge::GlueXHitTPOLwedge(G4int sector, G4int ring)
    ring_(ring), sector_(sector)
 {}
 
+
+GlueXHitTPOLwedge::GlueXHitTPOLwedge(const GlueXHitTPOLwedge &src)
+{
+   ring_ = src.ring_;
+   sector_ = src.sector_;
+   hits = src.hits;
+}
+
 int GlueXHitTPOLwedge::operator==(const GlueXHitTPOLwedge &right) const
 {
    if (sector_ !=  right.sector_ || ring_ != right.ring_)

--- a/src/GlueXHitTPOLwedge.hh
+++ b/src/GlueXHitTPOLwedge.hh
@@ -19,7 +19,9 @@
 class GlueXHitTPOLwedge : public G4VHit
 {
  public:
+   GlueXHitTPOLwedge() {}
    GlueXHitTPOLwedge(G4int sector, G4int ring=0);
+   GlueXHitTPOLwedge(const GlueXHitTPOLwedge &src);
    int operator==(const GlueXHitTPOLwedge &right) const;
    GlueXHitTPOLwedge &operator+=(const GlueXHitTPOLwedge &right);
 

--- a/src/GlueXHitUPVbar.cc
+++ b/src/GlueXHitUPVbar.cc
@@ -14,6 +14,13 @@ GlueXHitUPVbar::GlueXHitUPVbar(G4int layer, G4int row)
    row_(row)
 {}
 
+GlueXHitUPVbar::GlueXHitUPVbar(const GlueXHitUPVbar &src)
+{
+   layer_ = src.layer_;
+   row_ = src.row_;
+   hits = src.hits;
+}
+
 int GlueXHitUPVbar::operator==(const GlueXHitUPVbar &right) const
 {
    if (layer_ !=  right.layer_ || row_ != right.row_ )

--- a/src/GlueXHitUPVbar.hh
+++ b/src/GlueXHitUPVbar.hh
@@ -19,7 +19,9 @@
 class GlueXHitUPVbar : public G4VHit
 {
  public:
+   GlueXHitUPVbar() {}
    GlueXHitUPVbar(G4int layer, G4int row);
+   GlueXHitUPVbar(const GlueXHitUPVbar &src);
    int operator==(const GlueXHitUPVbar &right) const;
    GlueXHitUPVbar &operator+=(const GlueXHitUPVbar &right);
 

--- a/src/GlueXHitUPVpoint.cc
+++ b/src/GlueXHitUPVpoint.cc
@@ -8,6 +8,22 @@
 
 G4ThreadLocal G4Allocator<GlueXHitUPVpoint>* GlueXHitUPVpointAllocator = 0;
 
+GlueXHitUPVpoint::GlueXHitUPVpoint(const GlueXHitUPVpoint &src)
+{
+   E_GeV = src.E_GeV;
+   primary_ = src.primary_;
+   ptype_G3 = src.ptype_G3;
+   px_GeV = src.px_GeV;
+   py_GeV = src.py_GeV;
+   pz_GeV = src.pz_GeV;
+   x_cm = src.x_cm;
+   y_cm = src.y_cm;
+   z_cm = src.z_cm;
+   t_ns = src.t_ns;
+   track_ = src.track_;
+   trackID_ = src.trackID_;
+}
+
 int GlueXHitUPVpoint::operator==(const GlueXHitUPVpoint &right) const
 {
    if (E_GeV    != right.E_GeV    ||

--- a/src/GlueXHitUPVpoint.hh
+++ b/src/GlueXHitUPVpoint.hh
@@ -20,6 +20,7 @@ class GlueXHitUPVpoint : public G4VHit
 {
  public:
    GlueXHitUPVpoint() {}
+   GlueXHitUPVpoint(const GlueXHitUPVpoint &src);
    int operator==(const GlueXHitUPVpoint &right) const;
    GlueXHitUPVpoint &operator+=(const GlueXHitUPVpoint &right);
 

--- a/src/GlueXSensitiveDetectorBCAL.cc
+++ b/src/GlueXSensitiveDetectorBCAL.cc
@@ -113,7 +113,7 @@ GlueXSensitiveDetectorBCAL::~GlueXSensitiveDetectorBCAL()
 
 void GlueXSensitiveDetectorBCAL::Initialize(G4HCofThisEvent* hce)
 {
-   fCellsMap = new 
+   fCellsMap = new
               GlueXHitsMapBCALcell(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapBCALpoint(SensitiveDetectorName, collectionName[1]);
@@ -164,21 +164,21 @@ G4bool GlueXSensitiveDetectorBCAL::ProcessHits(G4Step* step,
           xin[0] * pin[0] + xin[1] * pin[1] > 0 &&
           Ein > THRESH_MEV*MeV)
       {
-         GlueXHitBCALpoint* newPoint = new GlueXHitBCALpoint();
+         GlueXHitBCALpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.z_cm = xin[2]/cm;
+         newPoint.r_cm = xin.perp()/cm;
+         newPoint.phi_rad = xin.phi();
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
          G4int key = fPointsMap->entries();
          fPointsMap->add(key, newPoint);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->z_cm = xin[2]/cm;
-         newPoint->r_cm = xin.perp()/cm;
-         newPoint->phi_rad = xin.phi();
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
          trackinfo->SetGlueXHistory(1);
  
          // The original HDGeant hits code for the BCal had a heavy-weight
@@ -229,8 +229,9 @@ G4bool GlueXSensitiveDetectorBCAL::ProcessHits(G4Step* step,
       int key = GlueXHitBCALcell::GetKey(module, layer, sector);
       GlueXHitBCALcell *cell = (*fCellsMap)[key];
       if (cell == 0) {
-         cell = new GlueXHitBCALcell(module, layer, sector);
-         fCellsMap->add(key, cell);
+         GlueXHitBCALcell newcell(module, layer, sector);
+         fCellsMap->add(key, newcell);
+         cell = (*fCellsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining strict time ordering

--- a/src/GlueXSensitiveDetectorCCAL.cc
+++ b/src/GlueXSensitiveDetectorCCAL.cc
@@ -100,7 +100,7 @@ GlueXSensitiveDetectorCCAL::~GlueXSensitiveDetectorCCAL()
 
 void GlueXSensitiveDetectorCCAL::Initialize(G4HCofThisEvent* hce)
 {
-   fBlocksMap = new 
+   fBlocksMap = new
               GlueXHitsMapCCALblock(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapCCALpoint(SensitiveDetectorName, collectionName[1]);
@@ -150,23 +150,23 @@ G4bool GlueXSensitiveDetectorCCAL::ProcessHits(G4Step* step,
    if (trackinfo->GetGlueXHistory() == 0 &&
        xin.dot(pin) > 0 && Ein/MeV > THRESH_MEV)
    {
-      GlueXHitCCALpoint* newPoint = new GlueXHitCCALpoint();
-      G4int key = fPointsMap->entries();
-      fPointsMap->add(key, newPoint);
       int pdgtype = track->GetDynamicParticle()->GetPDGcode();
       int g3type = GlueXPrimaryGeneratorAction::ConvertPdgToGeant3(pdgtype);
-      newPoint->ptype_G3 = g3type;
-      newPoint->track_ = trackID;
-      newPoint->trackID_ = itrack;
-      newPoint->primary_ = (track->GetParentID() == 0);
-      newPoint->t_ns = t/ns;
-      newPoint->x_cm = xin[0]/cm;
-      newPoint->y_cm = xin[1]/cm;
-      newPoint->z_cm = xin[2]/cm;
-      newPoint->px_GeV = pin[0]/GeV;
-      newPoint->py_GeV = pin[1]/GeV;
-      newPoint->pz_GeV = pin[2]/GeV;
-      newPoint->E_GeV = Ein/GeV;
+      GlueXHitCCALpoint newPoint;
+      newPoint.ptype_G3 = g3type;
+      newPoint.track_ = trackID;
+      newPoint.trackID_ = itrack;
+      newPoint.primary_ = (track->GetParentID() == 0);
+      newPoint.t_ns = t/ns;
+      newPoint.x_cm = xin[0]/cm;
+      newPoint.y_cm = xin[1]/cm;
+      newPoint.z_cm = xin[2]/cm;
+      newPoint.px_GeV = pin[0]/GeV;
+      newPoint.py_GeV = pin[1]/GeV;
+      newPoint.pz_GeV = pin[2]/GeV;
+      newPoint.E_GeV = Ein/GeV;
+      G4int key = fPointsMap->entries();
+      fPointsMap->add(key, newPoint);
       trackinfo->SetGlueXHistory(4);
    }
 
@@ -178,8 +178,9 @@ G4bool GlueXSensitiveDetectorCCAL::ProcessHits(G4Step* step,
       int key = GlueXHitCCALblock::GetKey(column, row);
       GlueXHitCCALblock *block = (*fBlocksMap)[key];
       if (block == 0) {
-         block = new GlueXHitCCALblock(column, row);
-         fBlocksMap->add(key, block);
+         GlueXHitCCALblock newblock(column, row);
+         fBlocksMap->add(key, newblock);
+         block = (*fBlocksMap)[key];
       }
       double dist = 0.5 * LENGTH_OF_BLOCK - xlocal[2];
       double dEcorr = dEsum * exp(-dist / ATTENUATION_LENGTH);

--- a/src/GlueXSensitiveDetectorCDC.cc
+++ b/src/GlueXSensitiveDetectorCDC.cc
@@ -175,7 +175,7 @@ GlueXSensitiveDetectorCDC::~GlueXSensitiveDetectorCDC()
 
 void GlueXSensitiveDetectorCDC::Initialize(G4HCofThisEvent* hce)
 {
-   fStrawsMap = new 
+   fStrawsMap = new
                 GlueXHitsMapCDCstraw(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
                 GlueXHitsMapCDCpoint(SensitiveDetectorName, collectionName[1]);
@@ -304,23 +304,23 @@ G4bool GlueXSensitiveDetectorCDC::ProcessHits(G4Step* step,
       if (lastPoint == 0 || lastPoint->track_ != trackID || 
           lastPoint->ring_ != ring)
       {
-         GlueXHitCDCpoint* newPoint = new GlueXHitCDCpoint();
+         GlueXHitCDCpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.r_cm = x.perp()/cm;
+         newPoint.phi_rad = x.phi();
+         newPoint.dradius_cm = dradius/cm;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.dEdx_GeV_cm = dEdx/(GeV/cm);
+         newPoint.sector_ = sector;
+         newPoint.ring_ = ring;
          fPointsMap->add(key, newPoint);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->r_cm = x.perp()/cm;
-         newPoint->phi_rad = x.phi();
-         newPoint->dradius_cm = dradius/cm;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->dEdx_GeV_cm = dEdx/(GeV/cm);
-         newPoint->sector_ = sector;
-         newPoint->ring_ = ring;
       }
    }
    
@@ -330,8 +330,9 @@ G4bool GlueXSensitiveDetectorCDC::ProcessHits(G4Step* step,
       int key = GlueXHitCDCstraw::GetKey(ring, sector);
       GlueXHitCDCstraw *straw = (*fStrawsMap)[key];
       if (straw == 0) {
-         straw = new GlueXHitCDCstraw(ring, sector);
-         fStrawsMap->add(key, straw);
+         GlueXHitCDCstraw newstraw(ring, sector);
+         fStrawsMap->add(key, newstraw);
+         straw = (*fStrawsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining track time ordering,

--- a/src/GlueXSensitiveDetectorCERE.cc
+++ b/src/GlueXSensitiveDetectorCERE.cc
@@ -93,7 +93,7 @@ GlueXSensitiveDetectorCERE::~GlueXSensitiveDetectorCERE()
 
 void GlueXSensitiveDetectorCERE::Initialize(G4HCofThisEvent* hce)
 {
-   fTubeHitsMap = new 
+   fTubeHitsMap = new
               GlueXHitsMapCEREtube(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapCEREpoint(SensitiveDetectorName, collectionName[1]);
@@ -153,20 +153,20 @@ G4bool GlueXSensitiveDetectorCERE::ProcessHits(G4Step* step,
              fabs(lastPoint->y_cm - x[1]/cm) > 2. ||
              fabs(lastPoint->z_cm - x[2]/cm) > 2.)
          {
-            GlueXHitCEREpoint* newPoint = new GlueXHitCEREpoint();
+            GlueXHitCEREpoint newPoint;
+            newPoint.ptype_G3 = g3type;
+            newPoint.track_ = trackID;
+            newPoint.trackID_ = itrack;
+            newPoint.primary_ = (track->GetParentID() == 0);
+            newPoint.t_ns = t/ns;
+            newPoint.x_cm = x[0]/cm;
+            newPoint.y_cm = x[1]/cm;
+            newPoint.z_cm = x[2]/cm;
+            newPoint.px_GeV = pin[0]/GeV;
+            newPoint.py_GeV = pin[1]/GeV;
+            newPoint.pz_GeV = pin[2]/GeV;
+            newPoint.E_GeV = Ein/GeV;
             fPointsMap->add(key, newPoint);
-            newPoint->ptype_G3 = g3type;
-            newPoint->track_ = trackID;
-            newPoint->trackID_ = itrack;
-            newPoint->primary_ = (track->GetParentID() == 0);
-            newPoint->t_ns = t/ns;
-            newPoint->x_cm = x[0]/cm;
-            newPoint->y_cm = x[1]/cm;
-            newPoint->z_cm = x[2]/cm;
-            newPoint->px_GeV = pin[0]/GeV;
-            newPoint->py_GeV = pin[1]/GeV;
-            newPoint->pz_GeV = pin[2]/GeV;
-            newPoint->E_GeV = Ein/GeV;
          }
       }
       // This sensitive detector is unique in that different volumes are used
@@ -182,8 +182,9 @@ G4bool GlueXSensitiveDetectorCERE::ProcessHits(G4Step* step,
       int key = GlueXHitCEREtube::GetKey(sector);
       GlueXHitCEREtube *counter = (*fTubeHitsMap)[key];
       if (counter == 0) {
-         counter = new GlueXHitCEREtube(sector);
-         fTubeHitsMap->add(key, counter);
+         GlueXHitCEREtube newcounter(sector);
+         fTubeHitsMap->add(key, newcounter);
+         counter = (*fTubeHitsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining strict time ordering

--- a/src/GlueXSensitiveDetectorFCAL.cc
+++ b/src/GlueXSensitiveDetectorFCAL.cc
@@ -111,7 +111,7 @@ GlueXSensitiveDetectorFCAL::~GlueXSensitiveDetectorFCAL()
 
 void GlueXSensitiveDetectorFCAL::Initialize(G4HCofThisEvent* hce)
 {
-   fBlocksMap = new 
+   fBlocksMap = new
               GlueXHitsMapFCALblock(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapFCALpoint(SensitiveDetectorName, collectionName[1]);
@@ -158,23 +158,23 @@ G4bool GlueXSensitiveDetectorFCAL::ProcessHits(G4Step* step,
    if (trackinfo->GetGlueXHistory() == 0 &&
        xin.dot(pin) > 0 && Ein/MeV > THRESH_MEV)
    {
-      GlueXHitFCALpoint* newPoint = new GlueXHitFCALpoint();
-      G4int key = fPointsMap->entries();
-      fPointsMap->add(key, newPoint);
       int pdgtype = track->GetDynamicParticle()->GetPDGcode();
       int g3type = GlueXPrimaryGeneratorAction::ConvertPdgToGeant3(pdgtype);
-      newPoint->ptype_G3 = g3type;
-      newPoint->track_ = trackID;
-      newPoint->trackID_ = itrack;
-      newPoint->primary_ = (track->GetParentID() == 0);
-      newPoint->t_ns = t/ns;
-      newPoint->x_cm = xin[0]/cm;
-      newPoint->y_cm = xin[1]/cm;
-      newPoint->z_cm = xin[2]/cm;
-      newPoint->px_GeV = pin[0]/GeV;
-      newPoint->py_GeV = pin[1]/GeV;
-      newPoint->pz_GeV = pin[2]/GeV;
-      newPoint->E_GeV = Ein/GeV;
+      GlueXHitFCALpoint newPoint;
+      newPoint.ptype_G3 = g3type;
+      newPoint.track_ = trackID;
+      newPoint.trackID_ = itrack;
+      newPoint.primary_ = (track->GetParentID() == 0);
+      newPoint.t_ns = t/ns;
+      newPoint.x_cm = xin[0]/cm;
+      newPoint.y_cm = xin[1]/cm;
+      newPoint.z_cm = xin[2]/cm;
+      newPoint.px_GeV = pin[0]/GeV;
+      newPoint.py_GeV = pin[1]/GeV;
+      newPoint.pz_GeV = pin[2]/GeV;
+      newPoint.E_GeV = Ein/GeV;
+      G4int key = fPointsMap->entries();
+      fPointsMap->add(key, newPoint);
       trackinfo->SetGlueXHistory(2);
    }
 
@@ -186,8 +186,9 @@ G4bool GlueXSensitiveDetectorFCAL::ProcessHits(G4Step* step,
       int key = GlueXHitFCALblock::GetKey(column, row);
       GlueXHitFCALblock *block = (*fBlocksMap)[key];
       if (block == 0) {
-         block = new GlueXHitFCALblock(column, row);
-         fBlocksMap->add(key, block);
+         GlueXHitFCALblock newblock(column, row);
+         fBlocksMap->add(key, newblock);
+         block = (*fBlocksMap)[key];
       }
 
       // Handle hits in the lead glass

--- a/src/GlueXSensitiveDetectorFDC.cc
+++ b/src/GlueXSensitiveDetectorFDC.cc
@@ -251,9 +251,9 @@ GlueXSensitiveDetectorFDC::~GlueXSensitiveDetectorFDC()
 
 void GlueXSensitiveDetectorFDC::Initialize(G4HCofThisEvent* hce)
 {
-   fWiresMap = new 
+   fWiresMap = new
                GlueXHitsMapFDCwire(SensitiveDetectorName, collectionName[0]);
-   fCathodesMap = new 
+   fCathodesMap = new
                GlueXHitsMapFDCcathode(SensitiveDetectorName, collectionName[1]);
    fPointsMap = new
                GlueXHitsMapFDCpoint(SensitiveDetectorName, collectionName[2]);
@@ -349,22 +349,22 @@ G4bool GlueXSensitiveDetectorFDC::ProcessHits(G4Step* step,
       if (lastPoint == 0 || lastPoint->track_ != trackID ||
           lastPoint->chamber_ != chamber)
       {
-         GlueXHitFDCpoint* newPoint = new GlueXHitFDCpoint(chamber);
+         GlueXHitFDCpoint newPoint(chamber);
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.track_ = trackID;
+         newPoint.x_cm = xout[0]/cm;
+         newPoint.y_cm = xout[1]/cm;
+         newPoint.z_cm = xout[2]/cm;
+         newPoint.t_ns = tout/ns;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         newPoint.dradius_cm = dradius/cm;
+         newPoint.dEdx_GeV_cm = dEdx/(GeV/cm);
+         newPoint.ptype_G3 = g3type;
+         newPoint.trackID_ = itrack;
          fPointsMap->add(key, newPoint);
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->track_ = trackID;
-         newPoint->x_cm = xout[0]/cm;
-         newPoint->y_cm = xout[1]/cm;
-         newPoint->z_cm = xout[2]/cm;
-         newPoint->t_ns = tout/ns;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
-         newPoint->dradius_cm = dradius/cm;
-         newPoint->dEdx_GeV_cm = dEdx/(GeV/cm);
-         newPoint->ptype_G3 = g3type;
-         newPoint->trackID_ = itrack;
       }
    }
 
@@ -427,8 +427,9 @@ G4bool GlueXSensitiveDetectorFDC::ProcessHits(G4Step* step,
          int key = GlueXHitFDCwire::GetKey(chamber, wire);
          GlueXHitFDCwire *anode = (*fWiresMap)[key];
          if (anode == 0) {
-            anode = new GlueXHitFDCwire(chamber, wire);
-            fWiresMap->add(key, anode);
+            GlueXHitFDCwire newanode(chamber, wire);
+            fWiresMap->add(key, newanode);
+            anode = (*fWiresMap)[key];
          }
 
          // Add the hit to the hits vector, maintaining track time ordering,
@@ -1021,8 +1022,9 @@ void GlueXSensitiveDetectorFDC::add_cathode_hit(
             int key = GlueXHitFDCcathode::GetKey(chamber, plane, strip);
             GlueXHitFDCcathode *cathode = (*fCathodesMap)[key];
             if (cathode == 0) {
-               cathode = new GlueXHitFDCcathode(chamber, plane, strip);
-               fCathodesMap->add(key, cathode);
+               GlueXHitFDCcathode newcathode(chamber, plane, strip);
+               fCathodesMap->add(key, newcathode);
+               cathode = (*fCathodesMap)[key];
             }
             std::vector<GlueXHitFDCcathode::hitinfo_t>::iterator hiter;
             for (hiter = cathode->hits.begin();

--- a/src/GlueXSensitiveDetectorFMWPC.cc
+++ b/src/GlueXSensitiveDetectorFMWPC.cc
@@ -90,7 +90,7 @@ GlueXSensitiveDetectorFMWPC::~GlueXSensitiveDetectorFMWPC()
 
 void GlueXSensitiveDetectorFMWPC::Initialize(G4HCofThisEvent* hce)
 {
-   fWireHitsMap = new 
+   fWireHitsMap = new
               GlueXHitsMapFMWPCwire(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapFMWPCpoint(SensitiveDetectorName, collectionName[1]);
@@ -147,22 +147,22 @@ G4bool GlueXSensitiveDetectorFMWPC::ProcessHits(G4Step* step,
           fabs(lastPoint->y_cm - x[1]/cm) > 2. ||
           fabs(lastPoint->z_cm - x[2]/cm) > 2.)
       {
-         GlueXHitFMWPCpoint* newPoint = new GlueXHitFMWPCpoint();
-         fPointsMap->add(key, newPoint);
          int pdgtype = track->GetDynamicParticle()->GetPDGcode();
          int g3type = GlueXPrimaryGeneratorAction::ConvertPdgToGeant3(pdgtype);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->x_cm = x[0]/cm;
-         newPoint->y_cm = x[1]/cm;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
+         GlueXHitFMWPCpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.x_cm = x[0]/cm;
+         newPoint.y_cm = x[1]/cm;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         fPointsMap->add(key, newPoint);
       }
    }
 
@@ -196,8 +196,9 @@ G4bool GlueXSensitiveDetectorFMWPC::ProcessHits(G4Step* step,
       int key = GlueXHitFMWPCwire::GetKey(layer, wire);
       GlueXHitFMWPCwire *counter = (*fWireHitsMap)[key];
       if (counter == 0) {
-         counter = new GlueXHitFMWPCwire(layer, wire);
-         fWireHitsMap->add(key, counter);
+         GlueXHitFMWPCwire newwire(layer, wire);
+         fWireHitsMap->add(key, newwire);
+         counter = (*fWireHitsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining strict time ordering

--- a/src/GlueXSensitiveDetectorFTOF.cc
+++ b/src/GlueXSensitiveDetectorFTOF.cc
@@ -108,7 +108,7 @@ GlueXSensitiveDetectorFTOF::~GlueXSensitiveDetectorFTOF()
 
 void GlueXSensitiveDetectorFTOF::Initialize(G4HCofThisEvent* hce)
 {
-   fBarHitsMap = new 
+   fBarHitsMap = new
               GlueXHitsMapFTOFbar(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapFTOFpoint(SensitiveDetectorName, collectionName[1]);
@@ -171,20 +171,20 @@ G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step,
           fabs(lastPoint->y_cm - x[1]/cm) > 2. ||
           fabs(lastPoint->z_cm - x[2]/cm) > 2.)
       {
-         GlueXHitFTOFpoint* newPoint = new GlueXHitFTOFpoint();
+         GlueXHitFTOFpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.x_cm = x[0]/cm;
+         newPoint.y_cm = x[1]/cm;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
          fPointsMap->add(key, newPoint);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->x_cm = x[0]/cm;
-         newPoint->y_cm = x[1]/cm;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
       }
    }
 
@@ -194,8 +194,9 @@ G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step,
       int key = GlueXHitFTOFbar::GetKey(plane, barNo);
       GlueXHitFTOFbar *counter = (*fBarHitsMap)[key];
       if (counter == 0) {
-         counter = new GlueXHitFTOFbar(plane, barNo);
-         fBarHitsMap->add(key, counter);
+         GlueXHitFTOFbar newcounter(plane, barNo);
+         fBarHitsMap->add(key, newcounter);
+         counter = (*fBarHitsMap)[key];
       }
 
       double dist = x[1]; // do not use local coordinate for x and y

--- a/src/GlueXSensitiveDetectorGCAL.cc
+++ b/src/GlueXSensitiveDetectorGCAL.cc
@@ -95,7 +95,7 @@ GlueXSensitiveDetectorGCAL::~GlueXSensitiveDetectorGCAL()
 
 void GlueXSensitiveDetectorGCAL::Initialize(G4HCofThisEvent* hce)
 {
-   fBlockHitsMap = new 
+   fBlockHitsMap = new
               GlueXHitsMapGCALblock(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapGCALpoint(SensitiveDetectorName, collectionName[1]);
@@ -147,23 +147,23 @@ G4bool GlueXSensitiveDetectorGCAL::ProcessHits(G4Step* step,
    if (trackinfo->GetGlueXHistory() == 0 && itrack > 0 &&
        xin.dot(pin) > 0 && Ein/MeV > THRESH_MEV)
    {
-      GlueXHitGCALpoint* newPoint = new GlueXHitGCALpoint();
-      G4int key = fPointsMap->entries();
-      fPointsMap->add(key, newPoint);
       int pdgtype = track->GetDynamicParticle()->GetPDGcode();
       int g3type = GlueXPrimaryGeneratorAction::ConvertPdgToGeant3(pdgtype);
-      newPoint->ptype_G3 = g3type;
-      newPoint->track_ = trackID;
-      newPoint->trackID_ = itrack;
-      newPoint->primary_ = (track->GetParentID() == 0);
-      newPoint->t_ns = t/ns;
-      newPoint->z_cm = x[2]/cm;
-      newPoint->r_cm = x.perp()/cm;
-      newPoint->phi_rad = x.phi();
-      newPoint->px_GeV = pin[0]/GeV;
-      newPoint->py_GeV = pin[1]/GeV;
-      newPoint->pz_GeV = pin[2]/GeV;
-      newPoint->E_GeV = Ein/GeV;
+      GlueXHitGCALpoint newPoint;
+      newPoint.ptype_G3 = g3type;
+      newPoint.track_ = trackID;
+      newPoint.trackID_ = itrack;
+      newPoint.primary_ = (track->GetParentID() == 0);
+      newPoint.t_ns = t/ns;
+      newPoint.z_cm = x[2]/cm;
+      newPoint.r_cm = x.perp()/cm;
+      newPoint.phi_rad = x.phi();
+      newPoint.px_GeV = pin[0]/GeV;
+      newPoint.py_GeV = pin[1]/GeV;
+      newPoint.pz_GeV = pin[2]/GeV;
+      newPoint.E_GeV = Ein/GeV;
+      G4int key = fPointsMap->entries();
+      fPointsMap->add(key, newPoint);
       trackinfo->SetGlueXHistory(3);
    }
 
@@ -173,8 +173,9 @@ G4bool GlueXSensitiveDetectorGCAL::ProcessHits(G4Step* step,
       int key = GlueXHitGCALblock::GetKey(module);
       GlueXHitGCALblock *block = (*fBlockHitsMap)[key];
       if (block == 0) {
-         block = new GlueXHitGCALblock(module);
-         fBlockHitsMap->add(key, block);
+         GlueXHitGCALblock newblock(module);
+         fBlockHitsMap->add(key, newblock);
+         block = (*fBlockHitsMap)[key];
       }
       double dist = 0.5 * LENGTH_OF_BLOCK - xlocal[2];
       double dEcorr = dEsum * exp(-dist / ATTENUATION_LENGTH);

--- a/src/GlueXSensitiveDetectorPS.cc
+++ b/src/GlueXSensitiveDetectorPS.cc
@@ -93,7 +93,7 @@ GlueXSensitiveDetectorPS::~GlueXSensitiveDetectorPS()
 
 void GlueXSensitiveDetectorPS::Initialize(G4HCofThisEvent* hce)
 {
-   fTileHitsMap = new 
+   fTileHitsMap = new
               GlueXHitsMapPStile(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapPSpoint(SensitiveDetectorName, collectionName[1]);
@@ -158,23 +158,23 @@ G4bool GlueXSensitiveDetectorPS::ProcessHits(G4Step* step,
           fabs(lastPoint->y_cm - x[1]/cm) > 5.0 ||
           fabs(lastPoint->z_cm - x[2]/cm) > 5.0)
       {
-         GlueXHitPSpoint* newPoint = new GlueXHitPSpoint();
+         GlueXHitPSpoint newPoint;
+         newPoint.arm_ = arm;
+         newPoint.column_ = column;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.x_cm = x[0]/cm;
+         newPoint.y_cm = x[1]/cm;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         newPoint.dEdx_GeV_cm = dEdx/(GeV/cm);
          fPointsMap->add(key, newPoint);
-         newPoint->arm_ = arm;
-         newPoint->column_ = column;
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->x_cm = x[0]/cm;
-         newPoint->y_cm = x[1]/cm;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
-         newPoint->dEdx_GeV_cm = dEdx/(GeV/cm);
       }
    }
 
@@ -184,8 +184,9 @@ G4bool GlueXSensitiveDetectorPS::ProcessHits(G4Step* step,
       int key = GlueXHitPStile::GetKey(arm, column);
       GlueXHitPStile *tile = (*fTileHitsMap)[key];
       if (tile == 0) {
-         tile = new GlueXHitPStile(arm, column);
-         fTileHitsMap->add(key, tile);
+         GlueXHitPStile newtile(arm, column);
+         fTileHitsMap->add(key, newtile);
+         tile = (*fTileHitsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining strict time ordering

--- a/src/GlueXSensitiveDetectorPSC.cc
+++ b/src/GlueXSensitiveDetectorPSC.cc
@@ -93,7 +93,7 @@ GlueXSensitiveDetectorPSC::~GlueXSensitiveDetectorPSC()
 
 void GlueXSensitiveDetectorPSC::Initialize(G4HCofThisEvent* hce)
 {
-   fCounterHitsMap = new 
+   fCounterHitsMap = new
               GlueXHitsMapPSCpaddle(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapPSCpoint(SensitiveDetectorName, collectionName[1]);
@@ -158,23 +158,23 @@ G4bool GlueXSensitiveDetectorPSC::ProcessHits(G4Step* step,
           fabs(lastPoint->y_cm - x[1]/cm) > 5.0 ||
           fabs(lastPoint->z_cm - x[2]/cm) > 5.0)
       {
-         GlueXHitPSCpoint* newPoint = new GlueXHitPSCpoint();
+         GlueXHitPSCpoint newPoint;
+         newPoint.arm_ = arm;
+         newPoint.module_ = module;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.x_cm = x[0]/cm;
+         newPoint.y_cm = x[1]/cm;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         newPoint.dEdx_GeV_cm = dEdx/(GeV/cm);
          fPointsMap->add(key, newPoint);
-         newPoint->arm_ = arm;
-         newPoint->module_ = module;
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->x_cm = x[0]/cm;
-         newPoint->y_cm = x[1]/cm;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
-         newPoint->dEdx_GeV_cm = dEdx/(GeV/cm);
       }
    }
 
@@ -184,8 +184,9 @@ G4bool GlueXSensitiveDetectorPSC::ProcessHits(G4Step* step,
       int key = GlueXHitPSCpaddle::GetKey(arm, module);
       GlueXHitPSCpaddle *paddle = (*fCounterHitsMap)[key];
       if (paddle == 0) {
-         paddle = new GlueXHitPSCpaddle(arm, module);
-         fCounterHitsMap->add(key, paddle);
+         GlueXHitPSCpaddle newpaddle(arm, module);
+         fCounterHitsMap->add(key, newpaddle);
+         paddle = (*fCounterHitsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining strict time ordering

--- a/src/GlueXSensitiveDetectorSTC.cc
+++ b/src/GlueXSensitiveDetectorSTC.cc
@@ -154,7 +154,7 @@ GlueXSensitiveDetectorSTC::~GlueXSensitiveDetectorSTC()
 
 void GlueXSensitiveDetectorSTC::Initialize(G4HCofThisEvent* hce)
 {
-   fHitsMap = new 
+   fHitsMap = new
               GlueXHitsMapSTCpaddle(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapSTCpoint(SensitiveDetectorName, collectionName[1]);
@@ -215,22 +215,22 @@ G4bool GlueXSensitiveDetectorSTC::ProcessHits(G4Step* step,
           fabs(lastPoint->t_ns - t/ns) > 0.1 ||
           fabs(lastPoint->z_cm - x[2]/cm) > 0.1)
       {
-         GlueXHitSTCpoint* newPoint = new GlueXHitSTCpoint();
+         GlueXHitSTCpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.sector_ = sector;
+         newPoint.t_ns = t/ns;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.r_cm = x.perp()/cm;
+         newPoint.phi_rad = x.phi();
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         newPoint.dEdx_GeV_cm = dEdx/(GeV/cm);
          fPointsMap->add(key, newPoint);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->sector_ = sector;
-         newPoint->t_ns = t/ns;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->r_cm = x.perp()/cm;
-         newPoint->phi_rad = x.phi();
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
-         newPoint->dEdx_GeV_cm = dEdx/(GeV/cm);
       }
    }
 
@@ -240,8 +240,9 @@ G4bool GlueXSensitiveDetectorSTC::ProcessHits(G4Step* step,
       int key = GlueXHitSTCpaddle::GetKey(sector);
       GlueXHitSTCpaddle *paddle = (*fHitsMap)[key];
       if (paddle == 0) {
-         paddle = new GlueXHitSTCpaddle(sector);
-         fHitsMap->add(key, paddle);
+         GlueXHitSTCpaddle newpaddle(sector);
+         fHitsMap->add(key, newpaddle);
+         paddle = (*fHitsMap)[key];
       }
 
       double dbent = 0.0;

--- a/src/GlueXSensitiveDetectorTPOL.cc
+++ b/src/GlueXSensitiveDetectorTPOL.cc
@@ -92,7 +92,7 @@ GlueXSensitiveDetectorTPOL::~GlueXSensitiveDetectorTPOL()
 
 void GlueXSensitiveDetectorTPOL::Initialize(G4HCofThisEvent* hce)
 {
-   fHitsMap = new 
+   fHitsMap = new
               GlueXHitsMapTPOLwedge(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapTPOLpoint(SensitiveDetectorName, collectionName[1]);
@@ -155,20 +155,20 @@ G4bool GlueXSensitiveDetectorTPOL::ProcessHits(G4Step* step,
           (fabs(lastPoint->r_cm - x.perp()/cm) > 0.1 &&
            fabs(lastPoint->phi_rad - x.phi()) > 0.1) )
       {
-         GlueXHitTPOLpoint* newPoint = new GlueXHitTPOLpoint();
+         GlueXHitTPOLpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = itrack;
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.phi_rad = x.phi();
+         newPoint.r_cm = x.perp()/cm;
+         newPoint.t_ns = t/ns;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         newPoint.dEdx_GeV_cm = dEdx/(GeV/cm);
          fPointsMap->add(key, newPoint);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = itrack;
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->phi_rad = x.phi();
-         newPoint->r_cm = x.perp()/cm;
-         newPoint->t_ns = t/ns;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
-         newPoint->dEdx_GeV_cm = dEdx/(GeV/cm);
       }
    }
 
@@ -178,8 +178,9 @@ G4bool GlueXSensitiveDetectorTPOL::ProcessHits(G4Step* step,
       int key = GlueXHitTPOLwedge::GetKey(sector, ring);
       GlueXHitTPOLwedge *wedge = (*fHitsMap)[key];
       if (wedge == 0) {
-         wedge = new GlueXHitTPOLwedge(sector, ring);
-         fHitsMap->add(key, wedge);
+         GlueXHitTPOLwedge newwedge(sector, ring);
+         fHitsMap->add(key, newwedge);
+         wedge = (*fHitsMap)[key];
       }
 
       // Add the hit to the hits vector, maintaining strict time ordering

--- a/src/GlueXSensitiveDetectorUPV.cc
+++ b/src/GlueXSensitiveDetectorUPV.cc
@@ -94,7 +94,7 @@ GlueXSensitiveDetectorUPV::~GlueXSensitiveDetectorUPV()
 
 void GlueXSensitiveDetectorUPV::Initialize(G4HCofThisEvent* hce)
 {
-   fBarHitsMap = new 
+   fBarHitsMap = new
               GlueXHitsMapUPVbar(SensitiveDetectorName, collectionName[0]);
    fPointsMap = new
               GlueXHitsMapUPVpoint(SensitiveDetectorName, collectionName[1]);
@@ -152,22 +152,22 @@ G4bool GlueXSensitiveDetectorUPV::ProcessHits(G4Step* step,
           fabs(lastPoint->y_cm - x[1]/cm) > 2. ||
           fabs(lastPoint->z_cm - x[2]/cm) > 2.)
       {
-         GlueXHitUPVpoint* newPoint = new GlueXHitUPVpoint();
-         fPointsMap->add(key, newPoint);
          int pdgtype = track->GetDynamicParticle()->GetPDGcode();
          int g3type = GlueXPrimaryGeneratorAction::ConvertPdgToGeant3(pdgtype);
-         newPoint->ptype_G3 = g3type;
-         newPoint->track_ = trackID;
-         newPoint->trackID_ = trackinfo->GetGlueXTrackID();
-         newPoint->primary_ = (track->GetParentID() == 0);
-         newPoint->t_ns = t/ns;
-         newPoint->x_cm = x[0]/cm;
-         newPoint->y_cm = x[1]/cm;
-         newPoint->z_cm = x[2]/cm;
-         newPoint->px_GeV = pin[0]/GeV;
-         newPoint->py_GeV = pin[1]/GeV;
-         newPoint->pz_GeV = pin[2]/GeV;
-         newPoint->E_GeV = Ein/GeV;
+         GlueXHitUPVpoint newPoint;
+         newPoint.ptype_G3 = g3type;
+         newPoint.track_ = trackID;
+         newPoint.trackID_ = trackinfo->GetGlueXTrackID();
+         newPoint.primary_ = (track->GetParentID() == 0);
+         newPoint.t_ns = t/ns;
+         newPoint.x_cm = x[0]/cm;
+         newPoint.y_cm = x[1]/cm;
+         newPoint.z_cm = x[2]/cm;
+         newPoint.px_GeV = pin[0]/GeV;
+         newPoint.py_GeV = pin[1]/GeV;
+         newPoint.pz_GeV = pin[2]/GeV;
+         newPoint.E_GeV = Ein/GeV;
+         fPointsMap->add(key, newPoint);
       }
    }
 
@@ -177,8 +177,9 @@ G4bool GlueXSensitiveDetectorUPV::ProcessHits(G4Step* step,
       int key = GlueXHitUPVbar::GetKey(layer, row);
       GlueXHitUPVbar *counter = (*fBarHitsMap)[key];
       if (counter == 0) {
-         counter = new GlueXHitUPVbar(layer, row);
-         fBarHitsMap->add(key, counter);
+         GlueXHitUPVbar newcounter(layer, row);
+         fBarHitsMap->add(key, newcounter);
+         counter = (*fBarHitsMap)[key];
       }
 
       double dxleft = xlocal[0];


### PR DESCRIPTION
  sensitive detector classes that use them, because of an abrupt change
  to the API for class G4THitsMap in release G4.10.04. The original add
  method supported either shallow-copy (pass by pointer) or deep-copy
  semantics (pass by reference), and I was using shallow copy because
  it is more efficient. Release G4.10.04 forces pass-by-pointer to do
  deep copies and hence behave the same as pass-by-reference. Why have
  both signatures if the behavior is the same?? This change is retro-
  active and changes to deep-copy semantics for all releases. [rtj]