### PR TITLE
- better to identify a decay process by its type than by the specific

### DIFF
--- a/src/GlueXSteppingAction.cc
+++ b/src/GlueXSteppingAction.cc
@@ -113,7 +113,7 @@ void GlueXSteppingAction::UserSteppingAction(const G4Step* step)
       if (primeID > 0) {
          const G4VProcess* process;
          process = step->GetPostStepPoint()->GetProcessDefinedStep();
-         if (dynamic_cast<const G4Decay*>(process)) {
+         if (process->GetProcessType() == fDecay) {
             G4TrackVector &secondary = *(G4TrackVector*)
                                         step->GetSecondaryInCurrentStep();
             G4TrackVector::iterator iter;


### PR DESCRIPTION
  class that one normally uses for this purpose. [rtj]