### PR TITLE
libgfortran.so must be searched because of fortran code in CCAL library.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -91,6 +91,7 @@ INTYLIBS += -L${XERCESCROOT}/lib -lxerces-c
 INTYLIBS += -L$(G4TMPDIR) -lhdds
 INTYLIBS += -lboost_python -L$(shell python-config --prefix)/lib $(shell python-config --ldflags)
 INTYLIBS += -L$(G4ROOT)/lib64 $(patsubst $(G4ROOT)/lib64/lib%.so, -l%, $(G4shared_libs))
+INTYLIBS += -lgfortran
 INTYLIBS += -L/usr/lib64
 
 EXTRALIBS += -lG4fixes

--- a/GNUmakefile.OSX
+++ b/GNUmakefile.OSX
@@ -82,6 +82,7 @@ INTYLIBS += -L${XERCESCROOT}/lib -lxerces-c
 INTYLIBS += -L$(G4TMPDIR) -lhdds
 INTYLIBS += -lboost_python $(shell python-config --libs)
 INTYLIBS += -L$(G4ROOT)/lib $(patsubst $(G4ROOT)/lib/lib%.dylib, -l%, $(G4shared_libs))
+INTYLIBS += -lgfortran
 
 .PHONY: all
 all: hdds cobrems sharedlib exe lib bin g4py


### PR DESCRIPTION
The same problem that we had with mcsmear in halld_sim.