### PR TITLE
* change bcal shower timing to use energy-weighted times,

### DIFF
--- a/src/GlueXHitBCALcell.cc
+++ b/src/GlueXHitBCALcell.cc
@@ -38,6 +38,10 @@ int GlueXHitBCALcell::operator==(const GlueXHitBCALcell &right) const
       if (hits[ih].E_GeV       != right.hits[ih].E_GeV     ||
           hits[ih].zlocal_cm   != right.hits[ih].zlocal_cm ||
           hits[ih].t_ns        != right.hits[ih].t_ns      ||
+          hits[ih].Eup_GeV     != right.hits[ih].Eup_GeV   ||
+          hits[ih].Edown_GeV   != right.hits[ih].Edown_GeV ||
+          hits[ih].tup_ns      != right.hits[ih].tup_ns    ||
+          hits[ih].tdown_ns    != right.hits[ih].tdown_ns  ||
           hits[ih].incidentId_ != right.hits[ih].incidentId_ )
       {
          return 0;
@@ -82,9 +86,13 @@ void GlueXHitBCALcell::Print() const
    std::vector<hitinfo_t>::const_iterator hiter;
    for (hiter = hits.begin(); hiter != hits.end(); ++hiter) {
       G4cout << "   E = " << hiter->E_GeV << " GeV" << G4endl
-             << "   zlocal = " << hiter->t_ns << " cm" << G4endl
              << "   t = " << hiter->t_ns << " ns" << G4endl
+             << "   zlocal = " << hiter->t_ns << " cm" << G4endl
              << "   incidentId = " << hiter->incidentId_ << G4endl
+             << "   E(upstream end) = " << hiter->Eup_GeV << " GeV" << G4endl
+             << "   E(downstream end) = " << hiter->Edown_GeV << " GeV" << G4endl
+             << "   t(upstream end) = " << hiter->tup_ns << " ns" << G4endl
+             << "   t(downstream end) = " << hiter->tdown_ns << " ns" << G4endl
              << G4endl;
    }
 }

--- a/src/GlueXHitBCALcell.hh
+++ b/src/GlueXHitBCALcell.hh
@@ -42,6 +42,10 @@ class GlueXHitBCALcell : public G4VHit
       G4double t_ns;        // pulse leading-edge time (ns)
       G4double zlocal_cm;   // z coordinate of the hit in local refsys
       G4double incidentId_; // id of particle that generated this shower
+      G4double Eup_GeV;     // upstream end energy deposition (GeV)
+      G4double Edown_GeV;   // downstream end energy deposition (GeV)
+      G4double tup_ns;      // upstream end pulse leading-edge time (ns)
+      G4double tdown_ns;    // downstream end pulse leading-edge time (ns)
    };
    std::vector<hitinfo_t> hits;
 


### PR DESCRIPTION
  to agree with FCAL timing algorithm, and also to be consistent
  to hdgeant.
* add code to fill hits info for light that reaches the upstream
  and downstream ends of the bcal (bcalSiPMUpHit, bcalSiPMDownHit).
  New code is needed in mcsmear to use this information rather than
  the bcalTruthHit which fails to simulate the way the readout
  actually works.