### PR TITLE
* change hard-coded energy rescale constants to symbolic form [rtj]

### DIFF
--- a/src/GlueXSensitiveDetectorBCAL.cc
+++ b/src/GlueXSensitiveDetectorBCAL.cc
@@ -22,6 +22,9 @@
 
 #define USE_ENERGY_WEIGHTED_TIMES 1
 
+// Energy rescale factor to match reconstructed to generated
+double GlueXSensitiveDetectorBCAL::SHOWER_ENERGY_SCALE_FACTOR = 1.04;
+
 // Cutoff on the total number of allowed hits
 int GlueXSensitiveDetectorBCAL::MAX_HITS = 100;
 
@@ -266,13 +269,13 @@ G4bool GlueXSensitiveDetectorBCAL::ProcessHits(G4Step* step,
          }
 #endif
          // correction factor makes shower yields match hdgeant
-         hiter->E_GeV += dEsum/GeV * 1.015;
+         hiter->E_GeV += dEsum/GeV * SHOWER_ENERGY_SCALE_FACTOR;
       }
       else if ((int)cell->hits.size() < MAX_HITS) {
          // create new hit 
          hiter = cell->hits.insert(hiter, GlueXHitBCALcell::hitinfo_t());
          // correction factor makes shower yields match hdgeant
-         hiter->E_GeV = dEsum/GeV * 1.015;
+         hiter->E_GeV = dEsum/GeV * SHOWER_ENERGY_SCALE_FACTOR;
          hiter->t_ns = t/ns;
          hiter->zlocal_cm = xlocal[2]/cm;
          hiter->incidentId_ = trackinfo->GetBCALincidentID();
@@ -310,13 +313,13 @@ G4bool GlueXSensitiveDetectorBCAL::ProcessHits(G4Step* step,
          }
 #endif
          // correction factor makes shower yields match hdgeant
-         hiter->Eup_GeV += dEup/GeV * 1.015;
+         hiter->Eup_GeV += dEup/GeV * SHOWER_ENERGY_SCALE_FACTOR;
       }
       else if ((int)cell->hits.size() < MAX_HITS) {
          // create new hit 
          hiter = cell->hits.insert(hiter, GlueXHitBCALcell::hitinfo_t());
          // correction factor makes shower yields match hdgeant
-         hiter->Eup_GeV = dEup/GeV * 1.015;
+         hiter->Eup_GeV = dEup/GeV * SHOWER_ENERGY_SCALE_FACTOR;
          hiter->tup_ns = tup/ns;
       }
       else {
@@ -352,13 +355,13 @@ G4bool GlueXSensitiveDetectorBCAL::ProcessHits(G4Step* step,
          }
 #endif
          // correction factor makes shower yields match hdgeant
-         hiter->Edown_GeV += dEdown/GeV * 1.015;
+         hiter->Edown_GeV += dEdown/GeV * SHOWER_ENERGY_SCALE_FACTOR;
       }
       else if ((int)cell->hits.size() < MAX_HITS) {
          // create new hit 
          hiter = cell->hits.insert(hiter, GlueXHitBCALcell::hitinfo_t());
          // correction factor makes shower yields match hdgeant
-         hiter->Edown_GeV = dEdown/GeV * 1.015;
+         hiter->Edown_GeV = dEdown/GeV * SHOWER_ENERGY_SCALE_FACTOR;
          hiter->tdown_ns = tdown/ns;
       }
       else {

--- a/src/GlueXSensitiveDetectorBCAL.hh
+++ b/src/GlueXSensitiveDetectorBCAL.hh
@@ -49,6 +49,7 @@ class GlueXSensitiveDetectorBCAL : public G4VSensitiveDetector
    static double MODULE_FULL_LENGTH;
    static double ATTENUATION_FULL_LENGTH;
    static double THRESH_ATTENUATED_GEV;
+   static double SHOWER_ENERGY_SCALE_FACTOR;
 
    static int instanceCount;
    static G4Mutex fMutex;

--- a/src/GlueXSensitiveDetectorFCAL.cc
+++ b/src/GlueXSensitiveDetectorFCAL.cc
@@ -20,6 +20,10 @@
 
 #include <JANA/JApplication.h>
 
+// Scale factors to match reconstructed to generated
+double GlueXSensitiveDetectorFCAL::SHOWER_ENERGY_SCALE_FACTOR =  0.976;
+double GlueXSensitiveDetectorFCAL::MIP_ENERGY_SCALE_FACTOR = 1.35;
+
 // Cutoff on the total number of allowed hits
 int GlueXSensitiveDetectorFCAL::MAX_HITS = 100;
 
@@ -201,11 +205,11 @@ G4bool GlueXSensitiveDetectorFCAL::ProcessHits(G4Step* step,
          // Apply effective response corrections, depending on particle type
          int pmass = track->GetDynamicParticle()->GetMass();
          if (pmass < 1 * MeV) { // must be one of e+,e-,gamma
-            dEcorr *= 0.976;
+            dEcorr *= SHOWER_ENERGY_SCALE_FACTOR;
          }
          else {
             double gamma = Ein / pmass; // nothing massless here
-            dEcorr *= (gamma > 1.25)? 1.35 : 0;
+            dEcorr *= (gamma > 1.25)? MIP_ENERGY_SCALE_FACTOR : 0;
          }
 
          if (dEcorr == 0)

--- a/src/GlueXSensitiveDetectorFCAL.hh
+++ b/src/GlueXSensitiveDetectorFCAL.hh
@@ -50,6 +50,8 @@ class GlueXSensitiveDetectorFCAL : public G4VSensitiveDetector
    static double C_EFFECTIVE;
    static double TWO_HIT_TIME_RESOL;
    static double THRESH_MEV;
+   static double SHOWER_ENERGY_SCALE_FACTOR;
+   static double MIP_ENERGY_SCALE_FACTOR;
 
    static int instanceCount;
    static G4Mutex fMutex;


### PR DESCRIPTION
  in GlueXSensitiveDetectorBCAL and GlueXSensitiveDetectorFCAL.
* adjust the BCAL scale factor up from 1.015 to 1.04 as per
  advice from M. Dalton based on study comparing shower energies
  in the bcal between hdgeant4 and hdgeant. [rtj]