### PR TITLE
* better documentation was requested by NJ for the DEBUG printout

### DIFF
--- a/src/GlueXEventAction.cc
+++ b/src/GlueXEventAction.cc
@@ -10,29 +10,9 @@
 #include "G4ios.hh"
 
 GlueXEventAction::GlueXEventAction()
- : G4UserEventAction()
-{
-   GlueXUserOptions *user_opts = GlueXUserOptions::GetInstance();
-   if (user_opts == 0) {
-      G4cerr << "Error in GlueXEventAction constructor - "
-             << "GlueXUserOptions::GetInstance() returns null, "
-             << "cannot continue." << G4endl;
-      exit(-1);
-   }
-
-   fDebugPrint[0] = 0;
-   fDebugPrint[1] = 0;
-   fDebugPrint[2] = 1;
-   std::map<int,int> debugpars;
-   if (user_opts->Find("DEBU", debugpars)) {
-      if (debugpars.find(1) != debugpars.end())
-         fDebugPrint[0] = debugpars[1];
-      if (debugpars.find(2) != debugpars.end())
-         fDebugPrint[1] = debugpars[2];
-      if (debugpars.find(3) != debugpars.end())
-         fDebugPrint[2] = debugpars[3];
-   }
-}
+ : G4UserEventAction(),
+   fProgressStep(0)
+{}
 
 void GlueXEventAction::BeginOfEventAction(const G4Event*)
 {}
@@ -43,9 +23,14 @@ void GlueXEventAction::EndOfEventAction(const G4Event* evt)
 
    // periodic printing
 
-   if (event_id % fDebugPrint[2] == 1 || 
-      (event_id >= fDebugPrint[0] && event_id < fDebugPrint[1]))
-   {
-      G4cout << ">>> Event " << event_id << G4endl;
+   if (fProgressStep == 0) {
+      long tens=1;
+      while (tens * 10 <= event_id)
+         tens *= 10;
+      if (event_id % tens == 0)
+         G4cout << event_id << " events simulated" << G4endl;
+   }
+   else if (event_id % fProgressStep == 0) {
+      G4cout << event_id << " events simulated" << G4endl;
    }
 }

--- a/src/GlueXEventAction.hh
+++ b/src/GlueXEventAction.hh
@@ -24,7 +24,7 @@ class GlueXEventAction : public G4UserEventAction
    void EndOfEventAction(const G4Event*);
 
  protected:
-   int fDebugPrint[3]; 
+   int fProgressStep; 
 };
 
 #endif

--- a/test/control.in
+++ b/test/control.in
@@ -395,11 +395,14 @@ c This card is only supported by hdgeant3.
 ABAN 0
 
 c The following card sets up the simulation to perform debugging on
-c a subset of the simulated events.
+c a subset of the simulated events. Debugging produces extra output
+c of information from the simulation, with specific content controlled
+c by the SWIT card (see above). 
 c DEBUG first last step
 c  - first (int) = event number of first event to debug
 c  - last (int) = event number of last event to debug
-c  - step (int) = only debug one event every step events
+c  - step (int) = after event last, minimal printout every step events
+c This card is only supported by hdgeant3.
 DEBU 1 10 1000
 
 c The following card can be used to turn off generation of secondary


### PR DESCRIPTION
  card, but it turned out to be inconsistent in its behavior between
  the g3 and g4 simulations. Remove DEBUG card support from hdgeant4
  and replace it with a simple power-of-ten progress printout. [rtj]