### PR TITLE
Remove use of libtirpc.so. This will be needed in the future, when...

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -97,7 +97,6 @@ INTYLIBS += -l$(BOOST_PYTHON_LIB) -L$(shell python-config --prefix)/lib $(shell 
 INTYLIBS += -L$(G4ROOT)/lib64 $(patsubst $(G4ROOT)/lib64/lib%.so, -l%, $(G4shared_libs))
 INTYLIBS += -lgfortran
 INTYLIBS += -L/usr/lib64
-INTYLIBS += -ltirpc
 
 EXTRALIBS += -lG4fixes
 


### PR DESCRIPTION
...librpc gets dropped, but for now it is breaking the build at JLab. Use of libtirpc was needed to build on Fedora 32. It we be re-added when the proper RPMs are installed at JLab.