### PR TITLE
 make FMWPC wire locations compatible with using cm as units

### DIFF
--- a/src/GlueXSensitiveDetectorFMWPC.cc
+++ b/src/GlueXSensitiveDetectorFMWPC.cc
@@ -184,13 +184,19 @@ G4bool GlueXSensitiveDetectorFMWPC::ProcessHits(G4Step* step,
       int wire = 0;
       if (layer % 2 != 0) {
          // Vertical wires
-         wire = floor(x[0] + 73.0);
+         wire = floor(x[0]/cm + 73.0);
       }
       else {
          // Horizontal wires
-         wire = floor(x[1] + 73.0);
+         wire = floor(x[1]/cm + 73.0);
+      }
+      if (layer == 6) {
+         // Vertical wires
+         wire = floor(x[0]/cm + 73.0);
       }
       
+      //cout<<"MWPC: layer/wire = "<<layer<<" / "<<wire<<endl;
+
       if (wire < 1 || wire > 144)
          return false;
       

--- a/src/GlueXSensitiveDetectorFMWPC.cc
+++ b/src/GlueXSensitiveDetectorFMWPC.cc
@@ -30,6 +30,12 @@ double GlueXSensitiveDetectorFMWPC::TWO_HIT_TIME_RESOL = 400*ns;
 // Minimum photoelectron count for a hit
 double GlueXSensitiveDetectorFMWPC::THRESH_KEV = 0.;
 
+// Coordinate of wire 0, transverse to wire direction
+double GlueXSensitiveDetectorFMWPC::WIRE_OFFSET = -73*cm;
+
+// Minimum photoelectron count for a hit
+double GlueXSensitiveDetectorFMWPC::WIRE_PITCH = 1.0*cm;
+
 int GlueXSensitiveDetectorFMWPC::instanceCount = 0;
 G4Mutex GlueXSensitiveDetectorFMWPC::fMutex = G4MUTEX_INITIALIZER;
 
@@ -184,15 +190,15 @@ G4bool GlueXSensitiveDetectorFMWPC::ProcessHits(G4Step* step,
       int wire = 0;
       if (layer % 2 != 0) {
          // Vertical wires
-         wire = floor(x[0]/cm + 73.0);
+         wire = floor(x[0] - WIRE_OFFSET)/WIRE_PITCH;
       }
       else {
          // Horizontal wires
-         wire = floor(x[1]/cm + 73.0);
+         wire = floor(x[1] - WIRE_OFFSET)/WIRE_PITCH;
       }
       if (layer == 6) {
          // Vertical wires
-         wire = floor(x[0]/cm + 73.0);
+         wire = floor(x[0] - WIRE_OFFSET)/WIRE_PITCH;
       }
       
       //cout<<"MWPC: layer/wire = "<<layer<<" / "<<wire<<endl;

--- a/src/GlueXSensitiveDetectorFMWPC.hh
+++ b/src/GlueXSensitiveDetectorFMWPC.hh
@@ -43,6 +43,8 @@ class GlueXSensitiveDetectorFMWPC : public G4VSensitiveDetector
    static int MAX_HITS;
    static double TWO_HIT_TIME_RESOL;
    static double THRESH_KEV;
+   static double WIRE_OFFSET;
+   static double WIRE_PITCH;
 
    static int instanceCount;
    static G4Mutex fMutex;


### PR DESCRIPTION
 for their location. Note these are still hard coded and will need
 a proper treatement using ccdb in the near future.
This also expects to use 6 chambers. and the last one having vertical wires.
Use this in combination with the latest geometry for the chamber which is 
currently only in hddm not in ccdb. This will be updated soon