### PR TITLE
Adjustments to makefile to work with new cmake system of Diracxx

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,10 +18,9 @@ ifndef G4SYSTEM
 endif
 
 ifdef DIRACXX_HOME
-    UNAME_P := $(shell uname -p)
-    DIRACXX_CMAKE := $(shell if [ -d $(DIRACXX_HOME)/$(UNAME_P) ]; then echo true; else echo false; fi)
+    DIRACXX_CMAKE := $(shell if [ -f $(DIRACXX_HOME)/CMakeLists.txt ]; then echo true; else echo false; fi)
     ifeq ($(DIRACXX_CMAKE), true)
-        CPPFLAGS += -I$(DIRACXX_HOME)/$(UNAME_P)/include -DUSING_DIRACXX -L$(DIRACXX_HOME)/$(UNAME_P)/lib -lDirac
+        CPPFLAGS += -I$(DIRACXX_HOME)/include -DUSING_DIRACXX -L$(DIRACXX_HOME)/lib -lDirac
     else
         CPPFLAGS += -I$(DIRACXX_HOME) -DUSING_DIRACXX -L$(DIRACXX_HOME) -lDirac
     endif

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,13 @@ ifndef G4SYSTEM
 endif
 
 ifdef DIRACXX_HOME
-    CPPFLAGS += -I$(DIRACXX_HOME)/include -DUSING_DIRACXX -L$(DIRACXX_HOME)/lib -lDirac
+    UNAME_P := $(shell uname -p)
+    DIRACXX_CMAKE := $(shell if [ -d $(DIRACXX_HOME)/$(UNAME_P) ]; then echo true; else echo false; fi)
+    ifeq ($(DIRACXX_CMAKE), true)
+        CPPFLAGS += -I$(DIRACXX_HOME)/$(UNAME_P)/include -DUSING_DIRACXX -L$(DIRACXX_HOME)/$(UNAME_P)/lib -lDirac
+    else
+        CPPFLAGS += -I$(DIRACXX_HOME) -DUSING_DIRACXX -L$(DIRACXX_HOME) -lDirac
+    endif
 endif
 
 PYTHON_CONFIG = python-config


### PR DESCRIPTION
This is in addition to those in the previous commit from Richard.

I noticed that with Diracxx, using the new cmake system, if you specify

  cmake -DCMAKE_INSTALL_PREFIX=$DIRACXX_HOME

then include, python, lib, etc. get installed into

  $DIRACXX_HOME/x86_64

where I am assuming that "x86_64" is the output of "uname -p"

If this is the intended behavior, which I am assuming it is, then the make file for hdgeant4 has to modified with a path that includes "x86_64" to find include and lib.

Adds some logic to allow backward compatibility with old make system as well.
