### PR TITLE
substitute a working URL for the particle type defs

### DIFF
--- a/test/control.in
+++ b/test/control.in
@@ -177,8 +177,9 @@ c type insert the Geant particle type code plus 100 (eg. 101=gamma,
 c 103=electron, 107=pi0, 108=pi+, 109=pi-, 114=proton).  If you use
 c the particle code but do not add 100 then theta,phi are ignored
 c and the particle direction is generated randomly over 4pi sr.
-c For a listing of the Geant particle types, see the following URL.
-c http://wwwasdoc.web.cern.ch/wwwasdoc/geant_html3/node72.html
+c For a listing of the Geant particle types, see CONS300 section of
+c the GEANT User's Guide at the following URL.
+c     http://cds.cern.ch/record/1082634
 c The meaning of the arguments to KINE are as follows.
 c  - particle = GEANT particle type of primary track + 100
 c  - momentum = initial track momentum, central value (GeV/c)


### PR DESCRIPTION
need a fix for a broken link