### PR TITLE
Fix for TAGH hits for the SRC/CT experiment

### DIFF
--- a/src/GlueXPseudoDetectorTAG.cc
+++ b/src/GlueXPseudoDetectorTAG.cc
@@ -121,12 +121,13 @@ int GlueXPseudoDetectorTAG::addTaggerPhoton(const G4Event *event,
    int micro_channel = -1;
    int hodo_channel = -1;
    double E = energy;
+
    if (E < MICRO_LIMITS_ERANGE[0] && E > MICRO_LIMITS_ERANGE[1]) {
       int i = MICRO_NCHANNELS * (E - MICRO_LIMITS_ERANGE[0]) /
               (MICRO_LIMITS_ERANGE[1] - MICRO_LIMITS_ERANGE[0]);
-      while (E < MICRO_CHANNEL_EMIN[i])
+      while (E < MICRO_CHANNEL_EMIN[i]) 
          ++i;
-      while (E > MICRO_CHANNEL_EMAX[i])
+      while (E > MICRO_CHANNEL_EMAX[i]) 
          --i;
       if (E >= MICRO_CHANNEL_EMIN[i] && E <= MICRO_CHANNEL_EMAX[i]) {
          E = (MICRO_CHANNEL_EMIN[i] + MICRO_CHANNEL_EMAX[i]) / 2;
@@ -136,15 +137,16 @@ int GlueXPseudoDetectorTAG::addTaggerPhoton(const G4Event *event,
    else if (E < HODO_LIMITS_ERANGE[0] && E > HODO_LIMITS_ERANGE[1]) {
       int i = HODO_NCHANNELS * (E - HODO_LIMITS_ERANGE[0]) /
               (HODO_LIMITS_ERANGE[1] - HODO_LIMITS_ERANGE[0]);
-      while (E < HODO_CHANNEL_EMIN[i])
+      while (E < HODO_CHANNEL_EMIN[i] || HODO_CHANNEL_EMAX[i] < 1.) 
          ++i;
-      while (E > HODO_CHANNEL_EMAX[i])
+      while (E > HODO_CHANNEL_EMAX[i] || HODO_CHANNEL_EMAX[i] < 1.) 
          --i;
       if (E >= HODO_CHANNEL_EMIN[i] && E <= HODO_CHANNEL_EMAX[i]) {
          E = (HODO_CHANNEL_EMIN[i] + HODO_CHANNEL_EMAX[i]) / 2;
          hodo_channel = HODO_CHANNEL_NUMBER[i];
       }
    }
+
    if (micro_channel < 0 && hodo_channel < 0)
       return false;
 


### PR DESCRIPTION
Skip over counters that were zeroed out in the CCDB table while trying to figure out the closest tagger hodoscope counter.

This is needed since simulations for the SRC/CT experiments were not registering TAGH hits below the microscope.

Part of the reason seems to be that the original guesses for the appropriate counters are a little off, but this seems to work well.