### PR TITLE
change energy scaling for FCAL MIPs to match muon data

### DIFF
--- a/src/GlueXSensitiveDetectorFCAL.cc
+++ b/src/GlueXSensitiveDetectorFCAL.cc
@@ -23,7 +23,7 @@
 
 // Scale factors to match reconstructed to generated
 double GlueXSensitiveDetectorFCAL::SHOWER_ENERGY_SCALE_FACTOR =  1.0;
-double GlueXSensitiveDetectorFCAL::MIP_ENERGY_SCALE_FACTOR = 1.35;
+double GlueXSensitiveDetectorFCAL::MIP_ENERGY_SCALE_FACTOR = 1.55;
 
 // Cutoff on the total number of allowed hits
 int GlueXSensitiveDetectorFCAL::MAX_HITS = 100;


### PR DESCRIPTION
Update energy matching scale factor for MIPs in FCAL.

Refs.:
https://halldweb.jlab.org/doc-private/DocDB/ShowDocument?docid=6234
https://halldweb.jlab.org/doc-private/DocDB/ShowDocument?docid=6220