### PR TITLE
Leading edge time for TOF, CTOF, PS and PSC

### DIFF
--- a/src/GlueXSensitiveDetectorCTOF.cc
+++ b/src/GlueXSensitiveDetectorCTOF.cc
@@ -233,9 +233,11 @@ G4bool GlueXSensitiveDetectorCTOF::ProcessHits(G4Step* step,
          }
 
          if (merge_hit) {
-            // sum the charge, do energy weighting of the time
-            hiter->t_ns = (hiter->dE_GeV * hiter->t_ns + dEtop/GeV * ttop/ns) /
-	      (hiter->dE_GeV += dEtop/GeV);
+	    // Use the time from the earlier hit but add the charge
+	    hiter->dE_GeV += dEtop/GeV;
+	    if (hiter->t_ns*ns > ttop) {
+		    hiter->t_ns = ttop/ns;
+	    }
          }
          else {
             // create new hit 
@@ -264,10 +266,11 @@ G4bool GlueXSensitiveDetectorCTOF::ProcessHits(G4Step* step,
             }
          }
          if (merge_hit) {
-            // sum the charge, do energy weighting of the time
-            hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
-                           dEbottom/GeV * tbottom/ns) /
-            (hiter->dE_GeV += dEbottom/GeV);
+            // Use the time from the earlier hit but add the charge
+	    hiter->dE_GeV += dEbottom/GeV;
+	    if (hiter->t_ns*ns > tbottom) {
+		    hiter->t_ns = tbottom/ns;
+	    }
          }
          else {
             // create new hit 

--- a/src/GlueXSensitiveDetectorFTOF.cc
+++ b/src/GlueXSensitiveDetectorFTOF.cc
@@ -262,11 +262,6 @@ G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step,
          }
 
          if (merge_hit) {
-            // sum the charge, do energy weighting of the time
-            //hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
-            //               dEnorth/GeV * tnorth/ns) /
-            //(hiter->dE_GeV += dEnorth/GeV);
-
 	    // Use the time from the earlier hit but add the charge
 	    hiter->dE_GeV += dEnorth/GeV;
 	    if (hiter->t_ns*ns > tnorth) {
@@ -333,11 +328,6 @@ G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step,
             }
          }
          if (merge_hit) {
-            // sum the charge, do energy weighting of the time
-            //hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
-            //               dEsouth/GeV * tsouth/ns) /
-            //(hiter->dE_GeV += dEsouth/GeV);
-
 	    // Use the time from the earlier hit but add the charge
 	    hiter->dE_GeV += dEsouth/GeV;
 	    if (hiter->t_ns*ns > tsouth) {

--- a/src/GlueXSensitiveDetectorFTOF.cc
+++ b/src/GlueXSensitiveDetectorFTOF.cc
@@ -263,9 +263,16 @@ G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step,
 
          if (merge_hit) {
             // sum the charge, do energy weighting of the time
-            hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
-                           dEnorth/GeV * tnorth/ns) /
-            (hiter->dE_GeV += dEnorth/GeV);
+            //hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
+            //               dEnorth/GeV * tnorth/ns) /
+            //(hiter->dE_GeV += dEnorth/GeV);
+
+	    // Use the time from the earlier hit but add the charge
+	    hiter->dE_GeV += dEnorth/GeV;
+	    if (hiter->t_ns*ns > tnorth) {
+		    hiter->t_ns = tnorth/ns;
+	    }
+
             std::vector<GlueXHitFTOFbar::hitextra_t>::reverse_iterator xiter;
             xiter = hiter->extra.rbegin();
             if (trackID != xiter->track_ || fabs(tin/ns - xiter->t_ns) > 0.1) {
@@ -327,9 +334,16 @@ G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step,
          }
          if (merge_hit) {
             // sum the charge, do energy weighting of the time
-            hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
-                           dEsouth/GeV * tsouth/ns) /
-            (hiter->dE_GeV += dEsouth/GeV);
+            //hiter->t_ns = (hiter->dE_GeV * hiter->t_ns +
+            //               dEsouth/GeV * tsouth/ns) /
+            //(hiter->dE_GeV += dEsouth/GeV);
+
+	    // Use the time from the earlier hit but add the charge
+	    hiter->dE_GeV += dEsouth/GeV;
+	    if (hiter->t_ns*ns > tsouth) {
+		    hiter->t_ns = tsouth/ns;
+	    }
+
             std::vector<GlueXHitFTOFbar::hitextra_t>::reverse_iterator xiter;
             xiter = hiter->extra.rbegin();
             if (trackID != xiter->track_ || fabs(tin/ns - xiter->t_ns) > 0.1) {

--- a/src/GlueXSensitiveDetectorPS.cc
+++ b/src/GlueXSensitiveDetectorPS.cc
@@ -204,10 +204,11 @@ G4bool GlueXSensitiveDetectorPS::ProcessHits(G4Step* step,
          }
       }
       if (merge_hit) {
-         // Add the charge, do energy-weighted time averaging
-         hiter->t_ns = (hiter->t_ns * hiter->dE_GeV + t/ns * dEsum/GeV) /
-                       (hiter->dE_GeV + dEsum/GeV);
-         hiter->dE_GeV += dEsum/GeV;
+	 // Use the time from the earlier hit but add the charge
+	 hiter->dE_GeV += dEsum/GeV;
+	 if (hiter->t_ns*ns > t) {
+		 hiter->t_ns = t/ns;
+	 }
       }
       else {
          // create new hit 

--- a/src/GlueXSensitiveDetectorPSC.cc
+++ b/src/GlueXSensitiveDetectorPSC.cc
@@ -204,10 +204,11 @@ G4bool GlueXSensitiveDetectorPSC::ProcessHits(G4Step* step,
          }
       }
       if (merge_hit) {
-         // Add the charge, do energy-weighted time averaging
-         hiter->t_ns = (hiter->t_ns * hiter->dE_GeV + t/ns * dEsum/GeV) /
-                       (hiter->dE_GeV + dEsum/GeV);
-         hiter->dE_GeV += dEsum/GeV;
+	 // Use the time from the earlier hit but add the charge
+	 hiter->dE_GeV += dEsum/GeV;
+	 if (hiter->t_ns*ns > t) {
+		 hiter->t_ns = t/ns;
+	 }
       }
       else {
          // create new hit 


### PR DESCRIPTION
TOF hit times in MC showed a much longer tail of late arrivals than in data, as discussed in the halld_recon issue https://github.com/JeffersonLab/halld_recon/issues/780.  

@sdobbs tracked this down to the merging of hits in the same channel which are within the 25 ns TOF_TWO_HIT_RESOL parameter.  The previous algorithm took an energy-weighted average of the hit time which lead to the long tail in the timing distribution in MC that is not observed in data.  This PR uses the earliest hit to set the time to match the leading edge time we use for these detectors in the electronics.