### PR TITLE
Fix 64-bit pointer truncation in boost python wrapper 

### DIFF
--- a/src/CobremsGeneration.cc
+++ b/src/CobremsGeneration.cc
@@ -1087,8 +1087,8 @@ void CobremsGeneration::pyApplyBeamCrystalConvolution(int nbins, pyobject xarr,
    typedef boost::python::tuple pytuple;
    pytuple xtuple = extract<pytuple>(xarr.attr("buffer_info")());
    pytuple ytuple = extract<pytuple>(yarr.attr("buffer_info")());
-   double *xbuf = reinterpret_cast<double*>((int)extract<int>(xtuple[0]));
-   double *ybuf = reinterpret_cast<double*>((int)extract<int>(ytuple[0]));
+   double *xbuf = reinterpret_cast<double*>((uintptr_t)extract<long>(xtuple[0]));
+   double *ybuf = reinterpret_cast<double*>((uintptr_t)extract<long>(ytuple[0]));
    applyBeamCrystalConvolution(nbins, xbuf, ybuf);
 }
 


### PR DESCRIPTION
Fixed overflow error in CobremsGeneration python interface caused by
casting 64-bit pointers to 32-bit integers in pyApplyBeamCrystalConvolution.

Changes:
- Use uintptr_t instead of int for pointer casting
- Use extract<long> instead of extract<int> for buffer addresses  

This resolves 'bad numeric conversion: positive overflow' errors
when using the cobrems python module on 64-bit systems.

Tested on Linux x86_64 with boost python 1.39 and python 3.9.
